### PR TITLE
Add rt.jar to bootstrap classpath for retrolambda

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.jakewharton:butterknife:7.0.1'
 
-    compile ("com.android.support:design:${rootProject.ext.androidSupportSdkVersion}") {
+    compile("com.android.support:design:${rootProject.ext.androidSupportSdkVersion}") {
         exclude module: 'appcompat-v7'
     }
     compile "com.android.support:recyclerview-v7:${rootProject.ext.androidSupportSdkVersion}"

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -62,6 +62,6 @@ final class AndroidLibraryRuleComposer {
         return new AndroidLibraryRule("src_${target.name}", ["PUBLIC"], deps, target.sources,
                 target.manifest, target.annotationProcessors as List, aptDeps, aidlRuleNames,
                 appClass, target.sourceCompatibility, target.targetCompatibility,
-                postprocessClassesCommands)
+                postprocessClassesCommands, target.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
@@ -58,6 +58,6 @@ final class ExopackageAndroidLibraryRuleComposer {
 
         return new ExopackageAndroidLibraryRule("app_lib_${target.name}", target.appClass,
                 ["PUBLIC"], deps, target.sourceCompatibility, target.targetCompatibility,
-                postprocessClassesCommands)
+                postprocessClassesCommands, target.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -62,6 +62,6 @@ final class JavaLibraryRuleComposer {
 
         new JavaLibraryRule("src_${target.name}", ["PUBLIC"], deps, target.sources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
-                target.targetCompatibility, postprocessClassesCommands)
+                target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/RetroLambdaGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/generator/RetroLambdaGenerator.groovy
@@ -24,7 +24,6 @@
 
 package com.github.piasy.okbuck.generator
 
-import com.github.piasy.okbuck.model.AndroidTarget
 import com.github.piasy.okbuck.model.JavaLibTarget
 import com.github.piasy.okbuck.util.FileUtil
 
@@ -42,20 +41,11 @@ final class RetroLambdaGenerator {
         output.createNewFile()
 
         FileUtil.copyResourceToProject("retrolambda/RetroLambda.sh", output)
-        File androidJar = null
-        if (target instanceof AndroidTarget) {
-            androidJar = new File(target.androidSdkDir, "platforms/android-${target.targetSdk}/android.jar")
-        }
 
         String outputText = output.text
         outputText = outputText.replaceAll('gen-dir', target.rootProject.file("buck-out/gen").absolutePath)
                 .replaceAll('retrolambda-jar', target.retroLambdaJar)
-
-        if (androidJar != null) {
-            outputText = outputText.replaceAll('android-jar', androidJar.absolutePath)
-        } else {
-            outputText = outputText.replaceAll(':android-jar:', ':')
-        }
+            outputText = outputText.replaceAll('android-jar', target.bootClasspath)
 
         output.text = outputText
 

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/model/AndroidTarget.groovy
@@ -11,6 +11,7 @@ import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
+
 /**
  * An Android target
  */
@@ -58,8 +59,14 @@ abstract class AndroidTarget extends JavaLibTarget {
         return javaVersion(project.android.compileOptions.targetCompatibility)
     }
 
-    File getAndroidSdkDir() {
-        return project.android.sdkDirectory
+    @Override
+    List<String> getJvmArgs() {
+        return extraJvmArgs
+    }
+
+    @Override
+    String getInitialBootCp() {
+        return baseVariant.javaCompile.options.bootClasspath
     }
 
     List<String> getBuildConfigFields() {

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/AndroidLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/AndroidLibraryRule.groovy
@@ -41,12 +41,14 @@ final class AndroidLibraryRule extends BuckRule {
     private final String mSourceCompatibility
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
+    private final List<String> mOptions
 
     AndroidLibraryRule(
             String name, List<String> visibility, List<String> deps, Set<String> srcSet,
             String manifest, List<String> annotationProcessors, List<String> aptDeps,
             List<String> aidlRuleNames, String appClass, String sourceCompatibility,
-            String targetCompatibility, List<String> postprocessClassesCommands) {
+            String targetCompatibility, List<String> postprocessClassesCommands,
+            List<String> options) {
         super("android_library", name, visibility, deps)
 
         mSrcSet = srcSet
@@ -58,6 +60,7 @@ final class AndroidLibraryRule extends BuckRule {
         mSourceCompatibility = sourceCompatibility
         mTargetCompatibility = targetCompatibility
         mPostprocessClassesCommands = postprocessClassesCommands
+        mOptions = options
     }
 
     @Override
@@ -107,6 +110,14 @@ final class AndroidLibraryRule extends BuckRule {
             printer.println("\tpostprocess_classes_commands = [")
             mPostprocessClassesCommands.each { String command ->
                 printer.println("\t\t'${command}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (!mOptions.empty) {
+            printer.println("\textra_arguments = [")
+            mOptions.each { String option ->
+                printer.println("\t\t'${option}',")
             }
             printer.println("\t],")
         }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/ExopackageAndroidLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/ExopackageAndroidLibraryRule.groovy
@@ -32,16 +32,18 @@ final class ExopackageAndroidLibraryRule extends BuckRule {
     private final String mSourceCompatibility
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
+    private final List<String> mOptions
 
     ExopackageAndroidLibraryRule(String name, String appClass, List<String> visibility,
                                  List<String> deps, String sourceCompatibility,
                                  String targetCompatibility,
-                                 List<String> postprocessClassesCommands) {
+                                 List<String> postprocessClassesCommands, List<String> options) {
         super("android_library", name, visibility, deps)
         mAppClass = appClass
         mSourceCompatibility = sourceCompatibility
         mTargetCompatibility = targetCompatibility
         mPostprocessClassesCommands = postprocessClassesCommands
+        mOptions = options
     }
 
     @Override
@@ -53,6 +55,14 @@ final class ExopackageAndroidLibraryRule extends BuckRule {
             printer.println("\tpostprocess_classes_commands = [")
             mPostprocessClassesCommands.each { String command ->
                 printer.println("\t\t'${command}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (!mOptions.empty) {
+            printer.println("\textra_arguments = [")
+            mOptions.each { String option ->
+                printer.println("\t\t'${option}',")
             }
             printer.println("\t],")
         }

--- a/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/JavaLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/piasy/okbuck/rule/JavaLibraryRule.groovy
@@ -35,11 +35,13 @@ final class JavaLibraryRule extends BuckRule {
     private final String mSourceCompatibility
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
+    private final List<String> mOptions
 
     JavaLibraryRule(String name, List<String> visibility, List<String> deps,
                     Set<String> srcSet, Set<String> annotationProcessors,
                     Set<String> annotationProcessorDeps, String sourceCompatibility,
-                    String targetCompatibility, List<String> postprocessClassesCommands) {
+                    String targetCompatibility, List<String> postprocessClassesCommands,
+                    List<String> options) {
         super("java_library", name, visibility, deps)
 
         mSrcSet = srcSet
@@ -48,6 +50,7 @@ final class JavaLibraryRule extends BuckRule {
         mSourceCompatibility = sourceCompatibility
         mTargetCompatibility = targetCompatibility
         mPostprocessClassesCommands = postprocessClassesCommands
+        mOptions = options
     }
 
     @Override
@@ -80,6 +83,14 @@ final class JavaLibraryRule extends BuckRule {
             printer.println("\tpostprocess_classes_commands = [")
             mPostprocessClassesCommands.each { String command ->
                 printer.println("\t\t'${command}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (!mOptions.empty) {
+            printer.println("\textra_arguments = [")
+            mOptions.each { String option ->
+                printer.println("\t\t'${option}',")
             }
             printer.println("\t],")
         }

--- a/install_buck.sh
+++ b/install_buck.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-git clone --depth 1 https://github.com/Piasy/buck.git && cd buck && ant
+git clone --depth 1 https://github.com/facebook/buck.git && cd buck && ant

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -62,6 +62,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+
     testCompile 'junit:junit:4.12'
     compile "com.android.support:appcompat-v7:${rootProject.ext.androidSupportSdkVersion}"
 }


### PR DESCRIPTION
With this change

- we no longer need https://github.com/facebook/buck/pull/732
- android jar path for retrolambda script is more straightforward
- we can add additional entries to the bootstrap classpath in the future if we need to