### PR TITLE
Add support for applicationIdSuffix

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -78,6 +78,7 @@ class AndroidAppTarget extends AndroidLibTarget {
 
     @Override
     protected void manipulateManifest(GPathResult manifest) {
+        manifest.@package = applicationIdWithSuffix
         manifest.@'android:versionCode' = versionCode.toString()
         manifest.@'android:versionName' = versionName
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -11,12 +11,14 @@ import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
 import org.gradle.api.Project
 import org.gradle.api.UnknownTaskException
+
 /**
  * An Android target
  */
 abstract class AndroidTarget extends JavaLibTarget {
 
     final String applicationId
+    final String applicationIdWithSuffix
     final String versionName
     final Integer versionCode
     final int minSdk
@@ -27,6 +29,11 @@ abstract class AndroidTarget extends JavaLibTarget {
         super(project, name)
 
         applicationId = baseVariant.applicationId
+        String suffix = ""
+        if (baseVariant.mergedFlavor.applicationIdSuffix != null) {
+            suffix += baseVariant.mergedFlavor.applicationIdSuffix
+        }
+        applicationIdWithSuffix = applicationId + suffix
         versionName = baseVariant.mergedFlavor.versionName
         versionCode = baseVariant.mergedFlavor.versionCode
         minSdk = baseVariant.mergedFlavor.minSdkVersion.apiLevel

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
@@ -32,7 +32,7 @@ import java.util.jar.JarFile
 @EqualsAndHashCode(includes = ["project", "name"])
 abstract class Target {
 
-    static final Set<String> APT_CONFIGURATIONS = ["apt", "provided"] as Set
+    static final Set<String> APT_CONFIGURATIONS = ["apt", "provided", 'compileOnly'] as Set
     static final String PROCESSOR_ENTRY =
             "META-INF/services/javax.annotation.processing.Processor"
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
@@ -25,25 +25,22 @@ package com.github.okbuilds.okbuck
 
 import org.gradle.api.Project
 
-/**
- * okbuck dsl.
- * */
 class OkBuckExtension {
 
     /**
      * build_tools_version
-     * */
+     */
     String buildToolVersion = "23.0.3"
 
     /**
      * Android target sdk version
-     * */
+     */
     String target = "android-23"
 
     /**
-     * overwrite: overwrite existing BUCK script or not.
-     * */
-    boolean overwrite = false
+     * Whether to overwrite existing generated buck files or not.
+     */
+    boolean overwrite = true
 
     /**
      * Annotation processor classes of project dependencies
@@ -51,29 +48,35 @@ class OkBuckExtension {
     Map<String, String> annotationProcessors = [:]
 
     /**
-     * linearAllocHardLimit used for multi-dex support.
-     * */
+     * LinearAllocHardLimit used for multi-dex support.
+     */
     Map<String, Integer> linearAllocHardLimit = [:]
 
     /**
-     * primary dex class patterns.
-     * */
+     * Primary dex class patterns.
+     */
     Map<String, List<String>> primaryDexPatterns = [:]
 
     /**
-     * whether to enable exopackage.
-     * */
+     * Whether to enable exopackage.
+     */
     Map<String, Boolean> exopackage = [:]
 
     /**
-     * exopackage lib dependencies.
-     * */
+     * Exopackage lib dependencies.
+     */
     Map<String, List<String>> appLibDependencies = [:]
 
     /**
      * Set of projects to generate buck configs for. Default is all subprojects of root project.
      */
     Set<Project> buckProjects
+
+    /**
+     * List of files to leave untouched when generating configuration.
+     * The override flag takes precedence over this list.
+     */
+    List<String> keep = []
 
     OkBuckExtension(Project project) {
         buckProjects = project.subprojects

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
@@ -24,8 +24,8 @@
 
 package com.github.okbuilds.okbuck
 
-import com.github.okbuilds.okbuck.config.BUCKFile
 import com.github.okbuilds.core.dependency.DependencyCache
+import com.github.okbuilds.okbuck.config.BUCKFile
 import com.github.okbuilds.okbuck.generator.BuckFileGenerator
 import com.github.okbuilds.okbuck.generator.DotBuckConfigGenerator
 import org.apache.commons.io.FileUtils
@@ -50,11 +50,10 @@ class OkBuckGradlePlugin implements Plugin<Project> {
         Task okBuckClean = project.task(OKBUCK_CLEAN)
         okBuckClean << {
             if (okbuck.overwrite) {
-                [".okbuck", ".buckd", "buck-out", ".buckconfig"].each { String file ->
+                [".okbuck", ".buckd", "buck-out", ".buckconfig"]
+                        .plus(okbuck.buckProjects.collect { it.file(BUCK).absolutePath })
+                        .minus(okbuck.keep).each { String file ->
                     FileUtils.deleteQuietly(project.file(file))
-                }
-                okbuck.buckProjects.each { Project buckProject ->
-                    FileUtils.deleteQuietly(buckProject.file(BUCK))
                 }
             }
         }
@@ -70,8 +69,8 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     private static generate(Project project) {
         OkBuckExtension okbuck = project.okbuck
 
-        if (okbuck.overwrite) {
-            println "==========>> okbuck overwrite mode is on <<=========="
+        if (!okbuck.overwrite) {
+            println "==========>> okbuck overwrite mode is off <<=========="
         }
 
         // generate .buckconfig


### PR DESCRIPTION
- Change overwrite mode to true by default (most common option for regular consumers)
- Provide option to keep some files from being cleaned up by the plugin when running okbuckclean. This is particularly useful to keep the buck-out folder around for faster incremental builds even when buck files are regenerated
- Also added the gradle `compileOnly` configuration to list of apt configurations. This has been available since gradle 2.12 natively
