### PR TITLE
Add experimental placeholder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ okbuck {
     ]
     buckProjects = project.subprojects
     keep = []
+
+    experimental {
+        placeholderSupport true
+    }
 }
 ```
 
@@ -98,6 +102,8 @@ please read the [Exopackage wiki page](https://github.com/OkBuilds/OkBuck/wiki/E
 + `annotationProcessors` is used to depend on annotation processors declared locally as another gradle module in the same root project.
 +  `buckProjects` is a set of projects to generate buck configs for. Default is all sub projects of the root project.
 + `keep` is a list of files to not clean up by the plugin when running `okbuckclean`. This may be useful to keep the `buck-out` folder around for faster incremental builds even when buck files are regenerated. Also useful if you want made manual modifications to some buck configuration and would like to keep it intact while regenerating the configuration for other projects.
++ `experimental` is used to enable experimental features not available in buck upstream, but available in our [fork](https://github.com/OkBuilds/buck/tree/okbuck)
+ - `placeholderSupport` - Enables supprot for [manifest placeholders](http://tools.android.com/tech-docs/new-build-system/user-guide/manifest-merger#TOC-Placeholder-support)
 + The keys used to configure various options can be either for 
  - All buildTypes and flavors i.e `app`
  - All buildTypes of a particular flavor i.e 'appDemo'

--- a/another-app/AndroidManifest.xml
+++ b/another-app/AndroidManifest.xml
@@ -28,7 +28,11 @@
         android:versionCode="0"
         android:versionName="1.0"
         >
-    <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="21"></uses-sdk>
+    <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="21"/>
+
+    <permission android:name="${applicationId}.permission"
+        android:label="${label}"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/another-app/build.gradle
+++ b/another-app/build.gradle
@@ -35,6 +35,8 @@ android {
         targetSdkVersion rootProject.ext.androidTargetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        manifestPlaceholders = [label: "custom permission"]
     }
 
     signingConfigs {

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ okbuck {
             ]
     ]
     buckProjects = project.subprojects.findAll { it.name != "plugin" }
+
+    experimental {
+        placeholderSupport true
+    }
 }
 
 task clean(type: Delete) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/annotation/Experimental.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/annotation/Experimental.groovy
@@ -1,0 +1,10 @@
+package com.github.okbuilds.core.annotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.SOURCE)
+@Target([ElementType.METHOD, ElementType.FIELD])
+@interface Experimental {}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -3,8 +3,10 @@ package com.github.okbuilds.core.model
 import com.android.build.gradle.api.BaseVariant
 import com.android.builder.model.SigningConfig
 import com.android.manifmerger.ManifestMerger2
+import com.github.okbuilds.core.annotation.Experimental
 import com.github.okbuilds.core.dependency.ExternalDependency
 import com.github.okbuilds.core.util.FileUtil
+import com.github.okbuilds.okbuck.ExperimentalExtension
 import com.github.okbuilds.okbuck.OkBuckExtension
 import groovy.transform.ToString
 import groovy.util.slurpersupport.GPathResult
@@ -37,6 +39,9 @@ class AndroidAppTarget extends AndroidLibTarget {
 
     final boolean minifyEnabled
 
+    @Experimental
+    final Map<String, Object> placeholders = [:]
+
     AndroidAppTarget(Project project, String name) {
         super(project, name)
 
@@ -57,6 +62,13 @@ class AndroidAppTarget extends AndroidLibTarget {
         appClass = extractAppClass()
 
         minifyEnabled = baseVariant.buildType.minifyEnabled
+
+        ExperimentalExtension experimental = okbuck.experimental
+        if (experimental.placeholderSupport) {
+            placeholders.put('applicationId', applicationId + applicationIdSuffix)
+            placeholders.putAll(baseVariant.buildType.manifestPlaceholders)
+            placeholders.putAll(baseVariant.mergedFlavor.manifestPlaceholders)
+        }
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
@@ -4,5 +4,7 @@ import org.apache.http.annotation.Experimental
 
 @Experimental
 class ExperimentalExtension {
+
+    // Enables support for manifest placeholders
     boolean placeholderSupport = false
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
@@ -1,0 +1,8 @@
+package com.github.okbuilds.okbuck
+
+import org.apache.http.annotation.Experimental
+
+@Experimental
+class ExperimentalExtension {
+    boolean placeholderSupport = false
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
@@ -39,11 +39,13 @@ class OkBuckGradlePlugin implements Plugin<Project> {
     static final String OKBUCK = "okbuck"
     static final String OKBUCK_CLEAN = 'okbuckClean'
     static final String BUCK = "BUCK"
+    static final String EXPERIMENTAL = "experimental"
 
     DependencyCache dependencyCache
 
     void apply(Project project) {
         OkBuckExtension okbuck = project.extensions.create(OKBUCK, OkBuckExtension, project)
+        ExperimentalExtension experimental = okbuck.extensions.create(EXPERIMENTAL, ExperimentalExtension)
 
         dependencyCache = new DependencyCache(project)
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
@@ -49,6 +49,6 @@ final class AndroidBinaryRuleComposer {
 
         return new AndroidBinaryRule("bin_${target.name}", ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
                 target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns, target.exopackage,
-                mappedCpuFilters, target.minifyEnabled, target.proguardConfig)
+                mappedCpuFilters, target.minifyEnabled, target.proguardConfig, target.placeholders)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidBinaryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidBinaryRule.groovy
@@ -42,11 +42,12 @@ final class AndroidBinaryRule extends BuckRule {
     private final Set<String> mCpuFilters
     private final boolean mMinifyEnabled
     private final String mProguardConfig
+    private final Map<String, Object> mPlaceholders
 
     AndroidBinaryRule(String name, List<String> visibility, List<String> deps, String manifest, String keystore,
                       boolean multidexEnabled, int linearAllocHardLimit, Set<String> primaryDexPatterns,
                       boolean exopackage, Set<String> cpuFilters, boolean minifyEnabled,
-                      String proguardConfig) {
+                      String proguardConfig, Map<String, Object> placeholders) {
         super("android_binary", name, visibility, deps)
 
         checkStringNotEmpty(manifest, "AndroidBinaryRule manifest must be set.")
@@ -61,6 +62,7 @@ final class AndroidBinaryRule extends BuckRule {
         mCpuFilters = cpuFilters
         mMinifyEnabled = minifyEnabled
         mProguardConfig = proguardConfig
+        mPlaceholders = placeholders
     }
 
     @Override
@@ -92,6 +94,16 @@ final class AndroidBinaryRule extends BuckRule {
             printer.println("\tpackage_type = 'release',")
             printer.println("\tandroid_sdk_proguard_config = 'none',")
             printer.println("\tproguard_config = '${mProguardConfig}',")
+        }
+
+        if (!mPlaceholders.isEmpty()) {
+            printer.println("\tmanifest_entries = {")
+            printer.println("\t\t'placeholders': {")
+            mPlaceholders.each { key, value ->
+                printer.println("\t\t\t'${key}': '${value}',")
+            }
+            printer.println("\t\t},")
+            printer.println("\t},")
         }
     }
 }

--- a/install_buck.sh
+++ b/install_buck.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-git clone --depth 1 https://github.com/OkBuilds/buck.git && cd buck && git checkout okbuck && ant
+
+git clone -b okbuck --single-branch --depth 1 https://github.com/OkBuilds/buck.git && cd buck && ant

--- a/install_buck.sh
+++ b/install_buck.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-git clone --depth 1 https://github.com/facebook/buck.git && cd buck && ant
+git clone --depth 1 https://github.com/OkBuilds/buck.git && cd buck && git checkout okbuck && ant


### PR DESCRIPTION
- Adds an experimental extension for new features not supported in buck upstream
- Adds support for manifest placeholders using our fork of buck
- Throw a helpful error if manifest merging failed due to some reason

Verified the generated manifest had placeholders filled in correctly

Resolves #86