### PR TITLE
Add support for generating `java_test` rule.

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
@@ -32,9 +32,17 @@ class JavaLibTarget extends Target {
         return project.files("src/main/java") as Set
     }
 
+    protected Set<File> testSourceDirs() {
+        return project.files("src/test/java") as Set
+    }
+
     @Override
     protected Set<String> compileConfigurations() {
         return ["compile"]
+    }
+
+    protected Set<String> testCompileConfigurations() {
+        return ["testCompile"]
     }
 
     String getSourceCompatibility() {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
@@ -42,11 +42,9 @@ final class FileUtil {
     }
 
     static void copyResourceToProject(String resource, File destination) {
-        try {
-            InputStream inputStream = FileUtil.getResourceAsStream(resource)
-            OutputStream outputStream = new FileOutputStream(destination)
-            outputStream.write(inputStream.bytes)
-            outputStream.close()
-        } catch (Exception ignored) { }
+        InputStream inputStream = FileUtil.getResourceAsStream(resource)
+        OutputStream outputStream = new FileOutputStream(destination)
+        outputStream.write(inputStream.bytes)
+        outputStream.close()
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Piasy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.okbuilds.okbuck.composer
+
+import com.github.okbuilds.okbuck.generator.RetroLambdaGenerator
+import com.github.okbuilds.core.model.JavaLibTarget
+import com.github.okbuilds.core.model.Target
+import com.github.okbuilds.okbuck.rule.JavaTestRule
+
+final class JavaTestRuleComposer {
+
+    private JavaTestRuleComposer() {
+        // no instance
+    }
+
+    static JavaTestRule compose(JavaLibTarget target) {
+        List<String> deps = [
+                ":src_${target.name}"
+        ]
+
+        deps.addAll(target.testCompileDeps.collect { String dep ->
+            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
+        })
+
+        deps.addAll(target.targetTestCompileDeps.collect { Target targetDep ->
+            "//${targetDep.path}:src_${targetDep.name}"
+        })
+
+        Set<String> aptDeps = [] as Set
+        aptDeps.addAll(target.aptDeps.collect { String dep ->
+            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
+        })
+
+        aptDeps.addAll(target.targetAptDeps.collect { Target targetDep ->
+            "//${targetDep.path}:src_${targetDep.name}"
+        })
+
+        List<String> postprocessClassesCommands = []
+        if (target.retrolambda) {
+            postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
+        }
+
+        new JavaTestRule("src_${target.testName}", ["PUBLIC"], deps, target.testSources,
+                target.annotationProcessors, aptDeps, target.sourceCompatibility,
+                target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
@@ -34,6 +34,7 @@ import com.github.okbuilds.okbuck.composer.AptRuleComposer
 import com.github.okbuilds.okbuck.composer.ExopackageAndroidLibraryRuleComposer
 import com.github.okbuilds.okbuck.composer.GenAidlRuleComposer
 import com.github.okbuilds.okbuck.composer.JavaLibraryRuleComposer
+import com.github.okbuilds.okbuck.composer.JavaTestRuleComposer
 import com.github.okbuilds.okbuck.composer.KeystoreRuleComposer
 import com.github.okbuilds.okbuck.composer.PreBuiltNativeLibraryRuleComposer
 import com.github.okbuilds.okbuck.config.BUCKFile
@@ -99,7 +100,8 @@ final class BuckFileGenerator {
     }
 
     private static List<BuckRule> createRules(JavaLibTarget target) {
-        return [JavaLibraryRuleComposer.compose(target)]
+        return [JavaLibraryRuleComposer.compose(target) as BuckRule,
+                JavaTestRuleComposer.compose(target) as BuckRule]
     }
 
     private static List<BuckRule> createRules(AndroidLibTarget target, String appClass = null) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaTestRule.groovy
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Piasy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.okbuilds.okbuck.rule
+/**
+ * java_test()
+ *
+ * TODO full buck support
+ * */
+final class JavaTestRule extends BuckRule {
+    private final Set<String> mSrcSet
+    private final Set<String> mAnnotationProcessors
+    private final Set<String> mAnnotationProcessorDeps
+    private final String mSourceCompatibility
+    private final String mTargetCompatibility
+    private final List<String> mPostprocessClassesCommands
+    private final List<String> mOptions
+
+    JavaTestRule(String name, List<String> visibility, List<String> deps,
+                    Set<String> srcSet, Set<String> annotationProcessors,
+                    Set<String> annotationProcessorDeps, String sourceCompatibility,
+                    String targetCompatibility, List<String> postprocessClassesCommands,
+                    List<String> options) {
+        super("java_test", name, visibility, deps)
+
+        mSrcSet = srcSet
+        mAnnotationProcessors = annotationProcessors
+        mAnnotationProcessorDeps = annotationProcessorDeps
+        mSourceCompatibility = sourceCompatibility
+        mTargetCompatibility = targetCompatibility
+        mPostprocessClassesCommands = postprocessClassesCommands
+        mOptions = options
+    }
+
+    @Override
+    protected final void printContent(PrintStream printer) {
+        printer.println("\tsrcs = glob([")
+        for (String src : mSrcSet) {
+            printer.println("\t\t'${src}/**/*.java',")
+        }
+        printer.println("\t]),")
+
+        if (!mAnnotationProcessors.empty) {
+            printer.println("\tannotation_processors = [")
+            mAnnotationProcessors.each { String processor ->
+                printer.println("\t\t'${processor}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (!mAnnotationProcessorDeps.empty) {
+            printer.println("\tannotation_processor_deps = [")
+            for (String dep : mAnnotationProcessorDeps) {
+                printer.println("\t\t'${dep}',")
+            }
+            printer.println("\t],")
+        }
+
+        printer.println("\tsource = '${mSourceCompatibility}',")
+        printer.println("\ttarget = '${mTargetCompatibility}',")
+        if (!mPostprocessClassesCommands.empty) {
+            printer.println("\tpostprocess_classes_commands = [")
+            mPostprocessClassesCommands.each { String command ->
+                printer.println("\t\t'${command}',")
+            }
+            printer.println("\t],")
+        }
+
+        if (!mOptions.empty) {
+            printer.println("\textra_arguments = [")
+            mOptions.each { String option ->
+                printer.println("\t\t'${option}',")
+            }
+            printer.println("\t],")
+        }
+    }
+}

--- a/libraries/javalibrary/src/test/java/com/github/okbuilds/okbuck/example/javalib/DummyTestJavaClass.java
+++ b/libraries/javalibrary/src/test/java/com/github/okbuilds/okbuck/example/javalib/DummyTestJavaClass.java
@@ -22,18 +22,18 @@
  * SOFTWARE.
  */
 
-apply plugin: 'java'
-apply plugin: 'nebula.provided-base'
-apply plugin: 'me.tatarka.retrolambda'
+package com.github.okbuilds.okbuck.example.javalib;
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+import org.junit.Test;
 
-dependencies {
-    compile 'com.google.code.gson:gson:2.6.2'
-    compile 'com.google.dagger:dagger:2.0.1'
-    provided 'org.glassfish:javax.annotation:10.0-b28'
-    provided 'com.google.dagger:dagger-compiler:2.0.1'
+import static org.junit.Assert.assertFalse;
 
-    testCompile 'junit:junit:4.12'
+public class DummyTestJavaClass {
+
+    @Test
+    public void testAssertFalse() {
+        assertFalse("failure - should be false", false);
+    }
+
 }
+


### PR DESCRIPTION
 - Example generated java_test rule:
```
java_test(
	name = 'src_test',
	srcs = glob([
		'src/test/java/**/*.java',
	]),
	source = '8',
	target = '8',
	postprocess_classes_commands = [
		'./.okbuck/retrolambda/libraries_javalibrary_main_RetroLambda.sh',
	],
	deps = [
		':src_main',
		'//.okbuck/cache/d101e78e05c3f923f9e6888984f3c78f:junit-4.12.jar',
		...
	],
	visibility = [
		'PUBLIC',
	],
)
```
 - Java test resources are not supported yet.