### PR TITLE
Extract common logic

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
@@ -1,10 +1,9 @@
 package com.github.okbuilds.core.dependency
 
 import com.github.okbuilds.core.util.FileUtil
+import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
-
-import java.security.MessageDigest
 
 class DependencyCache {
 
@@ -34,7 +33,7 @@ class DependencyCache {
         ExternalDependency greatestVersion = greatestVersions.get(dependency)
         if (!finalDepFiles.containsKey(greatestVersion)) {
             File depFile = greatestVersion.depFile
-            File cachedCopy = new File(cacheDir, "${md5(depFile.parentFile.absolutePath)}/${depFile.name}")
+            File cachedCopy = new File(cacheDir, "${DigestUtils.md5Hex(depFile.parentFile.absolutePath)}/${depFile.name}")
             if (!cachedCopy.exists()) {
                 FileUtils.copyFile(depFile, cachedCopy)
             }
@@ -57,11 +56,5 @@ class DependencyCache {
 
     private static boolean isValid(File dep) {
         return (dep.name.endsWith(".jar") || dep.name.endsWith(".aar"))
-    }
-
-    static String md5(String s) {
-        MessageDigest digest = MessageDigest.getInstance("MD5")
-        digest.update(s.bytes);
-        new BigInteger(1, digest.digest()).toString(16).padLeft(32, '0')
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -6,13 +6,12 @@ import com.android.builder.model.SourceProvider
 import com.android.manifmerger.ManifestMerger2
 import com.android.manifmerger.MergingReport
 import com.android.utils.ILogger
-import com.github.okbuilds.core.dependency.DependencyCache
 import com.github.okbuilds.core.util.FileUtil
 import groovy.transform.Memoized
 import groovy.transform.ToString
+import org.apache.commons.codec.digest.DigestUtils
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
-
 /**
  * An Android target
  */
@@ -180,7 +179,7 @@ abstract class AndroidTarget extends JavaLibTarget {
         ResBundle(String identifier, String resDir, String assetsDir) {
             this.resDir = resDir
             this.assetsDir = assetsDir
-            id = DependencyCache.md5("${identifier}:${resDir}:${assetsDir}")
+            id = DigestUtils.md5Hex("${identifier}:${resDir}:${assetsDir}")
         }
     }
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
@@ -3,11 +3,12 @@ package com.github.okbuilds.core.model
 import com.github.okbuilds.core.dependency.ExternalDependency
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.internal.jvm.Jvm
 
 /**
  * A java library target
  */
-class JavaLibTarget extends Target {
+class JavaLibTarget extends JavaTarget {
 
     private static final String RETRO_LAMBDA_CONFIG = "retrolambdaConfig"
     static final String MAIN = "main"
@@ -64,17 +65,13 @@ class JavaLibTarget extends Target {
     String getBootClasspath() {
         String bootCp = initialBootCp
         if (retrolambda) {
-            bootCp += ":${rtJar}"
+            bootCp += ":${Jvm.current().getRuntimeJar()}"
         }
         return bootCp
     }
 
     protected String getInitialBootCp() {
         return project.compileJava.options.bootClasspath
-    }
-
-    protected static String getRtJar() {
-        return "${System.properties.'java.home'}/lib/rt.jar"
     }
 
     protected static String javaVersion(JavaVersion version) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
@@ -1,0 +1,102 @@
+package com.github.okbuilds.core.model
+
+import com.github.okbuilds.core.dependency.ExternalDependency
+import com.github.okbuilds.okbuck.OkBuckExtension
+import org.apache.commons.io.IOUtils
+import org.gradle.api.Project
+
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+
+abstract class JavaTarget extends Target {
+
+    static final Set<String> APT_CONFIGURATIONS = ["apt", "provided", 'compileOnly'] as Set
+    static final String PROCESSOR_ENTRY =
+            "META-INF/services/javax.annotation.processing.Processor"
+
+    final Set<String> sources = [] as Set
+    final Set<String> testSources = [] as Set
+    final Set<JavaTarget> targetAptDeps = [] as Set
+    final Set<JavaTarget> targetCompileDeps = [] as Set
+    final Set<JavaTarget> targetTestCompileDeps = [] as Set
+
+    protected final Set<ExternalDependency> externalAptDeps = [] as Set
+    protected final Set<ExternalDependency> externalCompileDeps = [] as Set
+    protected final Set<ExternalDependency> externalTestCompileDeps = [] as Set
+
+    /**
+     * Constructor.
+     *
+     * @param project The project.
+     * @param name The target name.
+     */
+    JavaTarget(Project project, String name) {
+        super(project, name)
+
+        sources.addAll(getAvailable(sourceDirs()))
+        testSources.addAll(getAvailable(testSourceDirs()))
+
+        extractConfigurations(APT_CONFIGURATIONS, externalAptDeps, targetAptDeps)
+        OkBuckExtension okbuck = rootProject.okbuck
+        targetAptDeps.retainAll(targetAptDeps.findAll { JavaTarget target ->
+            target.getProp(okbuck.annotationProcessors, null) != null
+        })
+
+        extractConfigurations(compileConfigurations(), externalCompileDeps, targetCompileDeps)
+        extractConfigurations(testCompileConfigurations(), externalTestCompileDeps, targetTestCompileDeps)
+    }
+
+    /**
+     * List of source directories.
+     */
+    protected abstract Set<File> sourceDirs()
+
+    /**
+     * List of test source directories.
+     */
+    protected abstract Set<File> testSourceDirs()
+
+    /**
+     * List of compile configurations.
+     */
+    protected abstract Set<String> compileConfigurations()
+
+    /**
+     * List of test compile configurations.
+     */
+    protected abstract Set<String> testCompileConfigurations()
+
+    Set<String> getAnnotationProcessors() {
+        OkBuckExtension okbuck = rootProject.okbuck
+        return aptDeps.collect { String aptDep ->
+            JarFile jar = new JarFile(new File(aptDep))
+            jar.entries().findAll { JarEntry entry ->
+                entry.name.equals(PROCESSOR_ENTRY)
+            }.collect { JarEntry aptEntry ->
+                IOUtils.toString(jar.getInputStream(aptEntry)).trim().split("\\n")
+            }
+        }.plus(targetAptDeps.collect { JavaTarget target ->
+            (List<String>) target.getProp(okbuck.annotationProcessors, null)
+        }.findAll { List<String> processors ->
+            processors != null
+        }).flatten() as List<String>
+    }
+
+    Set<String> getCompileDeps() {
+        externalCompileDeps.collect { ExternalDependency dependency ->
+            dependencyCache.get(dependency)
+        }
+    }
+
+    Set<String> getTestCompileDeps() {
+        externalTestCompileDeps.collect { ExternalDependency dependency ->
+            dependencyCache.get(dependency)
+        }
+    }
+
+    Set<String> getAptDeps() {
+        externalAptDeps.collect { ExternalDependency dependency ->
+            dependencyCache.get(dependency)
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
@@ -4,20 +4,14 @@ import com.github.okbuilds.core.dependency.DependencyCache
 import com.github.okbuilds.core.dependency.ExternalDependency
 import com.github.okbuilds.core.util.FileUtil
 import com.github.okbuilds.core.util.ProjectUtil
-import com.github.okbuilds.okbuck.OkBuckExtension
 import com.github.okbuilds.okbuck.OkBuckGradlePlugin
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.io.IOUtils
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.UnknownConfigurationException
-
-import java.util.jar.JarEntry
-import java.util.jar.JarFile
-
 /**
  * A target is roughly equivalent to what can be built with gradle via the various assemble tasks.
  *
@@ -33,26 +27,11 @@ import java.util.jar.JarFile
 @EqualsAndHashCode(includes = ["project", "name"])
 abstract class Target {
 
-    static final Set<String> APT_CONFIGURATIONS = ["apt", "provided", 'compileOnly'] as Set
-    static final String PROCESSOR_ENTRY =
-            "META-INF/services/javax.annotation.processing.Processor"
-
     final Project project
     final Project rootProject
     final String name
-    final String testName
     final String identifier
     final String path
-
-    final Set<String> sources = [] as Set
-    final Set<String> testSources = [] as Set
-    final Set<Target> targetAptDeps = [] as Set
-    final Set<Target> targetCompileDeps = [] as Set
-    final Set<Target> targetTestCompileDeps = [] as Set
-
-    protected final Set<ExternalDependency> externalAptDeps = [] as Set
-    protected final Set<ExternalDependency> externalCompileDeps = [] as Set
-    protected final Set<ExternalDependency> externalTestCompileDeps = [] as Set
 
     /**
      * Constructor.
@@ -60,81 +39,14 @@ abstract class Target {
      * @param project The project.
      * @param name The target name.
      */
-    Target(Project project, String name, String testName = 'test') {
+    Target(Project project, String name) {
         this.project = project
         this.name = name
-        this.testName = testName
 
         identifier = project.path.replaceFirst(':', '')
         path = identifier.replaceAll(':', '/')
 
         rootProject = project.gradle.rootProject
-
-        sources.addAll(getAvailable(sourceDirs()))
-        testSources.addAll(getAvailable(testSourceDirs()))
-
-        extractConfigurations(APT_CONFIGURATIONS, externalAptDeps, targetAptDeps)
-        OkBuckExtension okbuck = rootProject.okbuck
-        targetAptDeps.retainAll(targetAptDeps.findAll { Target target ->
-            target.getProp(okbuck.annotationProcessors, null) != null
-        })
-
-        extractConfigurations(compileConfigurations(), externalCompileDeps, targetCompileDeps)
-        extractConfigurations(testCompileConfigurations(), externalTestCompileDeps, targetTestCompileDeps)
-    }
-
-    /**
-     * List of source directories.
-     */
-    protected abstract Set<File> sourceDirs()
-
-    /**
-     * List of test source directories.
-     */
-    protected abstract Set<File> testSourceDirs()
-
-    /**
-     * List of compile configurations.
-     */
-    protected abstract Set<String> compileConfigurations()
-
-    /**
-     * List of test compile configurations.
-     */
-    protected abstract Set<String> testCompileConfigurations()
-
-    Set<String> getAnnotationProcessors() {
-        OkBuckExtension okbuck = rootProject.okbuck
-        return aptDeps.collect { String aptDep ->
-            JarFile jar = new JarFile(new File(aptDep))
-            jar.entries().findAll { JarEntry entry ->
-                entry.name.equals(PROCESSOR_ENTRY)
-            }.collect { JarEntry aptEntry ->
-                IOUtils.toString(jar.getInputStream(aptEntry)).trim().split("\\n")
-            }
-        }.plus(targetAptDeps.collect { Target target ->
-            (List<String>) target.getProp(okbuck.annotationProcessors, null)
-        }.findAll { List<String> processors ->
-            processors != null
-        }).flatten() as List<String>
-    }
-
-    Set<String> getCompileDeps() {
-        externalCompileDeps.collect { ExternalDependency dependency ->
-            dependencyCache.get(dependency)
-        }
-    }
-
-    Set<String> getTestCompileDeps() {
-        externalTestCompileDeps.collect { ExternalDependency dependency ->
-            dependencyCache.get(dependency)
-        }
-    }
-
-    Set<String> getAptDeps() {
-        externalAptDeps.collect { ExternalDependency dependency ->
-            dependencyCache.get(dependency)
-        }
     }
 
     protected Set<String> getAvailable(Collection<File> files) {
@@ -145,12 +57,12 @@ abstract class Target {
         }
     }
 
-    protected DependencyCache getDependencyCache() {
+    DependencyCache getDependencyCache() {
         return ((OkBuckGradlePlugin) rootProject.plugins
                 .getPlugin(OkBuckGradlePlugin)).dependencyCache
     }
 
-    protected void extractConfigurations(Set<String> configurations, Set<ExternalDependency> externalConfigurationDeps,
+    void extractConfigurations(Set<String> configurations, Set<ExternalDependency> externalConfigurationDeps,
                                          Set<Target> targetConfigurationDeps) {
         configurations.each { String configName ->
             try {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/GitUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/GitUtil.groovy
@@ -52,13 +52,4 @@ class GitUtil {
     static String remoteName(String gitUrl) {
         return DigestUtils.md5Hex(gitUrl)
     }
-
-    /**
-     * Cleans and resets the state of a git repository
-     * @param repoDir The git repository directory
-     */
-    static void cleanReset(File repoDir) {
-        CmdUtil.run("git -C ${repoDir.absolutePath} reset --hard")
-        CmdUtil.run("git -C ${repoDir.absolutePath} clean -fdx")
-    }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
@@ -3,7 +3,7 @@ package com.github.okbuilds.okbuck.composer
 import com.github.okbuilds.core.model.AndroidAppTarget
 import com.github.okbuilds.okbuck.rule.AndroidBinaryRule
 
-final class AndroidBinaryRuleComposer {
+final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
 
     private static Map<String, String> CPU_FILTER_MAP = [
             "armeabi"    : "ARM",
@@ -23,7 +23,7 @@ final class AndroidBinaryRuleComposer {
             CPU_FILTER_MAP.get(cpuFilter)
         }.findAll { String cpuFilter -> cpuFilter != null }
 
-        return new AndroidBinaryRule("bin_${target.name}", ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
+        return new AndroidBinaryRule(bin(target), ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
                 target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns, target.exopackage,
                 mappedCpuFilters, target.minifyEnabled, target.proguardConfig, target.placeholders)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
@@ -1,0 +1,39 @@
+package com.github.okbuilds.okbuck.composer
+
+import com.github.okbuilds.core.model.AndroidAppTarget
+import com.github.okbuilds.core.model.AndroidTarget
+
+abstract class AndroidBuckRuleComposer extends JavaBuckRuleComposer {
+
+    static String res(AndroidTarget target, AndroidTarget.ResBundle bundle) {
+        return "//${target.path}:${resLocal(target, bundle)}"
+    }
+
+    static String resLocal(AndroidTarget target, AndroidTarget.ResBundle bundle) {
+        return "res_${target.name}_${bundle.id}"
+    }
+
+    static String manifest(AndroidTarget target) {
+        return "manifest_${target.name}"
+    }
+
+    static String buildConfig(AndroidTarget target) {
+        return "build_config_${target.name}"
+    }
+
+    static String prebuiltNative(AndroidTarget target, String jniLibDir) {
+        return "prebuilt_native_library_${target.name}_${jniLibDir.replaceAll("/", "_")}"
+    }
+
+    static String aidl(AndroidTarget target) {
+        return "${target.name}_aidls"
+    }
+
+    static String appLib(AndroidTarget target) {
+        return "app_lib_${target.name}"
+    }
+
+    static String bin(AndroidAppTarget target) {
+        return "bin_${target.name}"
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuildConfigRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuildConfigRuleComposer.groovy
@@ -3,14 +3,14 @@ package com.github.okbuilds.okbuck.composer
 import com.github.okbuilds.core.model.AndroidTarget
 import com.github.okbuilds.okbuck.rule.AndroidBuildConfigRule
 
-final class AndroidBuildConfigRuleComposer {
+final class AndroidBuildConfigRuleComposer extends AndroidBuckRuleComposer {
 
     private AndroidBuildConfigRuleComposer() {
         // no instance
     }
 
     static AndroidBuildConfigRule compose(AndroidTarget target) {
-        return new AndroidBuildConfigRule("build_config_${target.name}", ["PUBLIC"],
-                target.applicationId, target.buildConfigFields)
+        return new AndroidBuildConfigRule(buildConfig(target), ["PUBLIC"], target.applicationId,
+                target.buildConfigFields)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidManifestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidManifestRuleComposer.groovy
@@ -5,7 +5,7 @@ import com.github.okbuilds.core.model.AndroidLibTarget
 import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.rule.AndroidManifestRule
 
-final class AndroidManifestRuleComposer {
+final class AndroidManifestRuleComposer extends AndroidBuckRuleComposer {
 
     private AndroidManifestRuleComposer() {
         // no instance
@@ -14,18 +14,14 @@ final class AndroidManifestRuleComposer {
     static AndroidManifestRule compose(AndroidAppTarget target) {
         List<String> deps = []
 
-        deps.addAll(target.compileDeps.findAll { String dep ->
+        deps.addAll(external(target.compileDeps.findAll { String dep ->
             dep.endsWith("aar")
-        }.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
+        }))
 
-        deps.addAll(target.targetCompileDeps.findAll { Target targetDep ->
+        deps.addAll(targets(target.targetCompileDeps.findAll { Target targetDep ->
             targetDep instanceof AndroidLibTarget
-        }.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        }))
 
-        return new AndroidManifestRule("manifest_${target.name}", ["PUBLIC"], deps, target.manifest)
+        return new AndroidManifestRule(manifest(target), ["PUBLIC"], deps, target.manifest)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -4,7 +4,7 @@ import com.github.okbuilds.core.model.AndroidTarget
 import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.rule.AndroidResourceRule
 
-final class AndroidResourceRuleComposer {
+final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
 
     private AndroidResourceRuleComposer() {
         // no instance
@@ -13,21 +13,19 @@ final class AndroidResourceRuleComposer {
     static AndroidResourceRule compose(AndroidTarget target, AndroidTarget.ResBundle resBundle) {
         List<String> resDeps = new ArrayList<>()
 
-        resDeps.addAll(target.compileDeps.findAll { String dep ->
+        resDeps.addAll(external(target.compileDeps.findAll { String dep ->
             dep.endsWith(".aar")
-        }.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
+        }))
 
         target.targetCompileDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {
                 targetDep.resources.each { AndroidTarget.ResBundle bundle ->
-                    resDeps.add("//${targetDep.path}:res_${targetDep.name}_${bundle.id}")
+                    resDeps.add(res(targetDep, bundle))
                 }
             }
         }
 
-        return new AndroidResourceRule("res_${target.name}_${resBundle.id}", ["PUBLIC"], resDeps,
+        return new AndroidResourceRule(resLocal(target, resBundle), ["PUBLIC"], resDeps,
                 target.applicationId, resBundle.resDir, resBundle.assetsDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AptRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AptRuleComposer.groovy
@@ -3,17 +3,13 @@ package com.github.okbuilds.okbuck.composer
 import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.rule.AptRule
 
-final class AptRuleComposer {
+final class AptRuleComposer extends JavaBuckRuleComposer {
 
     private AptRuleComposer() {
         // no instance
     }
 
     static AptRule compose(Target target) {
-        List<String> aptDeps = target.aptDeps.collect { String aptDep ->
-            "//${aptDep.reverse().replaceFirst("/", ":").reverse()}"
-        }
-
-        return new AptRule("apt_jar_${target.name}", aptDeps)
+        return new AptRule(aptJar(target), external(target.aptDeps) as List)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/BuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/BuckRuleComposer.groovy
@@ -1,0 +1,18 @@
+package com.github.okbuilds.okbuck.composer
+
+import com.github.okbuilds.core.model.Target
+
+abstract class BuckRuleComposer {
+
+    static Set<String> external(Set<String> deps) {
+        return deps.collect { String dep ->
+            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
+        }
+    }
+
+    static Set<String> targets(Set<Target> deps) {
+        return deps.collect { Target targetDep ->
+            "//${targetDep.path}:src_${targetDep.name}"
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/GenAidlRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/GenAidlRuleComposer.groovy
@@ -1,20 +1,16 @@
 package com.github.okbuilds.okbuck.composer
 
 import com.github.okbuilds.core.model.AndroidTarget
-import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.rule.GenAidlRule
 
-final class GenAidlRuleComposer {
+final class GenAidlRuleComposer extends AndroidBuckRuleComposer {
 
     private GenAidlRuleComposer() {
         // no instance
     }
 
     static GenAidlRule compose(AndroidTarget target, String aidlDir) {
-        return new GenAidlRule("${target.name}_aidls", aidlDir,
-                "${target.path}/${aidlDir}",
-                target.targetCompileDeps.collect { Target targetDep ->
-                    "//${targetDep.path}:src_${targetDep.name}"
-                } as Set)
+        return new GenAidlRule(aidl(target), aidlDir, "${target.path}/${aidlDir}",
+                targets(target.targetCompileDeps))
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaBuckRuleComposer.groovy
@@ -1,0 +1,18 @@
+package com.github.okbuilds.okbuck.composer
+
+import com.github.okbuilds.core.model.JavaTarget
+
+abstract class JavaBuckRuleComposer extends BuckRuleComposer {
+
+    static String src(JavaTarget target) {
+        return "src_${target.name}"
+    }
+
+    static String test(JavaTarget target) {
+        return "test_${target.name}"
+    }
+
+    static String aptJar(JavaTarget target) {
+        return "apt_jar_${target.name}"
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -1,11 +1,10 @@
 package com.github.okbuilds.okbuck.composer
 
 import com.github.okbuilds.core.model.JavaLibTarget
-import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.generator.RetroLambdaGenerator
 import com.github.okbuilds.okbuck.rule.JavaLibraryRule
 
-final class JavaLibraryRuleComposer {
+final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
 
     private JavaLibraryRuleComposer() {
         // no instance
@@ -13,30 +12,19 @@ final class JavaLibraryRuleComposer {
 
     static JavaLibraryRule compose(JavaLibTarget target) {
         List<String> deps = []
-
-        deps.addAll(target.compileDeps.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
-
-        deps.addAll(target.targetCompileDeps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        deps.addAll(external(target.compileDeps))
+        deps.addAll(targets(target.targetCompileDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(target.aptDeps.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
-
-        aptDeps.addAll(target.targetAptDeps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        aptDeps.addAll(external(target.aptDeps))
+        aptDeps.addAll(targets(target.targetAptDeps))
 
         List<String> postprocessClassesCommands = []
         if (target.retrolambda) {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaLibraryRule("src_${target.name}", ["PUBLIC"], deps, target.sources,
+        new JavaLibraryRule(src(target), ["PUBLIC"], deps, target.sources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
                 target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
@@ -1,44 +1,30 @@
 package com.github.okbuilds.okbuck.composer
 
 import com.github.okbuilds.core.model.JavaLibTarget
-import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.generator.RetroLambdaGenerator
 import com.github.okbuilds.okbuck.rule.JavaTestRule
 
-final class JavaTestRuleComposer {
+final class JavaTestRuleComposer extends JavaBuckRuleComposer {
 
     private JavaTestRuleComposer() {
         // no instance
     }
 
     static JavaTestRule compose(JavaLibTarget target) {
-        List<String> deps = [
-                ":src_${target.name}"
-        ]
-
-        deps.addAll(target.testCompileDeps.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
-
-        deps.addAll(target.targetTestCompileDeps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        List<String> deps = [":${src(target)}"]
+        deps.addAll(external(target.testCompileDeps))
+        deps.addAll(targets(target.targetTestCompileDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(target.aptDeps.collect { String dep ->
-            "//${dep.reverse().replaceFirst("/", ":").reverse()}"
-        })
-
-        aptDeps.addAll(target.targetAptDeps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        aptDeps.addAll(external(target.aptDeps))
+        aptDeps.addAll(targets(target.targetAptDeps))
 
         List<String> postprocessClassesCommands = []
         if (target.retrolambda) {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaTestRule("src_${target.testName}", ["PUBLIC"], deps, target.testSources,
+        new JavaTestRule(test(target), ["PUBLIC"], deps, target.testSources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
                 target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/PreBuiltNativeLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/PreBuiltNativeLibraryRuleComposer.groovy
@@ -3,14 +3,14 @@ package com.github.okbuilds.okbuck.composer
 import com.github.okbuilds.core.model.AndroidTarget
 import com.github.okbuilds.okbuck.rule.PrebuiltNativeLibraryRule
 
-final class PreBuiltNativeLibraryRuleComposer {
+final class PreBuiltNativeLibraryRuleComposer extends AndroidBuckRuleComposer {
 
     private PreBuiltNativeLibraryRuleComposer() {
         // no instance
     }
 
     static PrebuiltNativeLibraryRule compose(AndroidTarget target, String jniLibDir) {
-        String ruleName = "prebuilt_native_library_${target.name}_${jniLibDir.replaceAll("/", "_")}"
-        return new PrebuiltNativeLibraryRule(ruleName, Arrays.asList("PUBLIC"), jniLibDir)
+        return new PrebuiltNativeLibraryRule(prebuiltNative(target, jniLibDir),
+                Arrays.asList("PUBLIC"), jniLibDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
@@ -86,9 +86,7 @@ final class BuckFileGenerator {
             rules.add(aptRule)
             aptDeps.add(":${aptRule.name}")
         }
-        aptDeps.addAll(target.targetAptDeps.collect { Target targetDep ->
-            "//${targetDep.path}:src_${targetDep.name}"
-        })
+        aptDeps.addAll(BuckRuleComposer.targets(target.targetAptDeps))
 
         // Jni
         androidLibRules.addAll(target.jniLibs.collect { String jniLib ->
@@ -109,7 +107,7 @@ final class BuckFileGenerator {
 
     private static List<BuckRule> createRules(AndroidAppTarget target) {
         List<BuckRule> rules = []
-        List<String> deps = [":src_${target.name}"]
+        List<String> deps = [":${AndroidBuckRuleComposer.src(target)}"]
 
         Set<BuckRule> libRules = createRules((AndroidLibTarget) target,
                 target.exopackage ? target.appClass : null)

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/DotBuckConfigLocalGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/DotBuckConfigLocalGenerator.groovy
@@ -4,6 +4,7 @@ import com.github.okbuilds.core.model.ProjectType
 import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.core.util.ProjectUtil
 import com.github.okbuilds.okbuck.OkBuckExtension
+import com.github.okbuilds.okbuck.composer.AndroidBuckRuleComposer
 import com.github.okbuilds.okbuck.config.DotBuckConfigLocalFile
 import org.gradle.api.Project
 
@@ -20,7 +21,8 @@ final class DotBuckConfigLocalGenerator {
             ProjectUtil.getType(project) == ProjectType.ANDROID_APP
         }.each { Project project ->
             ProjectUtil.getTargets(project).each { String name, Target target ->
-                aliases.put("${target.identifier}${name.capitalize()}", "//${target.path}:bin_${name}")
+                aliases.put("${target.identifier}${name.capitalize()}",
+                        "//${target.path}:${AndroidBuckRuleComposer.bin(target)}")
             }
         }
 


### PR DESCRIPTION
- Change base `Target` to not contain any java based logic
- Abstract out rule name generation inside composers
- Remove some unneeded methods 