### PR TITLE
Add new Scope Model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ notifications:
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -rf $HOME/.gradle/caches/*/scripts/
 cache:
   directories:
-    - $HOME/.gradle/caches/
+    - $HOME/.gradle/caches/modules-2/
     - $HOME/.gradle/wrapper/

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -4,17 +4,13 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.builder.model.SigningConfig
 import com.android.manifmerger.ManifestMerger2
 import com.github.okbuilds.core.annotation.Experimental
-import com.github.okbuilds.core.dependency.ExternalDependency
 import com.github.okbuilds.core.util.FileUtil
 import com.github.okbuilds.okbuck.ExperimentalExtension
-import com.github.okbuilds.okbuck.OkBuckExtension
 import groovy.transform.ToString
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.lang3.tuple.Pair
 import org.gradle.api.Project
-import org.gradle.api.file.FileTree
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
@@ -31,11 +27,11 @@ class AndroidAppTarget extends AndroidLibTarget {
     final Keystore keystore
     final Set<String> cpuFilters
 
-    final boolean exopackage
     final int linearAllocHardLimit
     final Set<String> primaryDexPatterns
     final Set<String> exoPackageDependencies
-    final String appClass
+
+    final ExoPackageScope exopackage
 
     final boolean minifyEnabled
 
@@ -45,8 +41,8 @@ class AndroidAppTarget extends AndroidLibTarget {
     AndroidAppTarget(Project project, String name) {
         super(project, name)
 
-        multidexEnabled = baseVariant.mergedFlavor.multiDexEnabled
         debuggable = baseVariant.buildType.debuggable
+        minifyEnabled = baseVariant.buildType.minifyEnabled
         keystore = extractKeystore()
         if (baseVariant.ndkCompile.abiFilters != null) {
             cpuFilters = baseVariant.ndkCompile.abiFilters
@@ -54,14 +50,16 @@ class AndroidAppTarget extends AndroidLibTarget {
             cpuFilters = [] as Set
         }
 
-        OkBuckExtension okbuck = rootProject.okbuck
-        exopackage = getProp(okbuck.exopackage, false)
+        multidexEnabled = baseVariant.mergedFlavor.multiDexEnabled
         primaryDexPatterns = getProp(okbuck.primaryDexPatterns, []) as Set
-        exoPackageDependencies = getProp(okbuck.appLibDependencies, []) as Set
         linearAllocHardLimit = getProp(okbuck.linearAllocHardLimit, DEFAULT_LINEARALLOC_LIMIT) as Integer
-        appClass = extractAppClass()
 
-        minifyEnabled = baseVariant.buildType.minifyEnabled
+        exoPackageDependencies = getProp(okbuck.appLibDependencies, []) as Set
+        if (getProp(okbuck.exopackage, false)) {
+            exopackage = new ExoPackageScope(project, main, exoPackageDependencies, manifest)
+        } else {
+            exopackage = null
+        }
 
         ExperimentalExtension experimental = okbuck.experimental
         if (experimental.placeholderSupport) {
@@ -128,52 +126,6 @@ class AndroidAppTarget extends AndroidLibTarget {
         return mergedManifest
     }
 
-    Pair<Set<String>, Set<Target>> getAppLibDependencies() {
-        Set<String> externalDeps = [] as Set
-        Set<Target> projectDeps = [] as Set
-        exoPackageDependencies.each { String exoPackageDep ->
-            String first // can denote either group or project name
-            String last // can denote either module or configuration name
-            boolean fullyQualified = false
-
-            if (exoPackageDep.contains(":")) {
-                List<String> parts = exoPackageDep.split(":")
-                first = parts[0]
-                last = parts[1]
-                fullyQualified = true
-            } else {
-                first = last = exoPackageDep
-            }
-
-            ExternalDependency external = externalCompileDeps.find { ExternalDependency externalDependency ->
-                boolean match = true
-                if (fullyQualified) {
-                    match &= externalDependency.group == first
-                }
-                match &= externalDependency.module == last
-                return match
-            }
-
-            if (external != null) {
-                externalDeps.add(dependencyCache.get(external))
-            } else {
-                Target variantDep = targetCompileDeps.find { Target variant ->
-                    boolean match = true
-                    if (fullyQualified) {
-                        match &= variant.name == last
-                    }
-                    match &= variant.path == first
-                    return match
-                }
-
-                if (variantDep != null) {
-                    projectDeps.add(variantDep)
-                }
-            }
-        }
-        return Pair.of(externalDeps, projectDeps)
-    }
-
     String getProguardConfig() {
         File mergedProguardConfig = project.file("${project.buildDir}/okbuck/${name}/proguard.pro")
         mergedProguardConfig.parentFile.mkdirs()
@@ -184,7 +136,7 @@ class AndroidAppTarget extends AndroidLibTarget {
         configs.addAll(baseVariant.buildType.proguardFiles)
 
         // Consumer proguard files of target dependencies
-        configs.addAll((targetCompileDeps.findAll { Target target ->
+        configs.addAll((main.targetDeps.findAll { Target target ->
             target instanceof AndroidLibTarget
         } as List<AndroidLibTarget>).collect { AndroidLibTarget target ->
             target.baseVariant.mergedFlavor.consumerProguardFiles +
@@ -198,7 +150,7 @@ class AndroidAppTarget extends AndroidLibTarget {
         }
 
         // Consumer proguard files of compiled aar dependencies
-        compileDeps.findAll { String dep ->
+        main.externalDeps.findAll { String dep ->
             dep.endsWith(".aar")
         }.each { String dep ->
             String config = getPackedProguardConfig(rootProject.file(dep))
@@ -235,28 +187,6 @@ class AndroidAppTarget extends AndroidLibTarget {
         } else {
             return null
         }
-    }
-
-    private String extractAppClass() {
-        String appClass = null
-        XmlSlurper slurper = new XmlSlurper()
-        slurper.DTDHandler = null
-        GPathResult manifestXml = slurper.parse(project.file(manifest))
-        try {
-            appClass = manifestXml.application.@"android:name"
-            appClass = appClass.replaceAll('\\.', "/")
-        } catch (Exception ignored) {
-        }
-        if (appClass != null && !appClass.empty) {
-            sources.each { String sourceDir ->
-                FileTree found = project.fileTree(dir: sourceDir, includes:
-                        ["${appClass}.java"])
-                if (found.size() == 1) {
-                    appClass = FileUtil.getRelativePath(project.projectDir, found[0])
-                }
-            }
-        }
-        return appClass
     }
 
     @ToString(includes = [])

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -12,6 +12,7 @@ import groovy.transform.ToString
 import org.apache.commons.codec.digest.DigestUtils
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
+
 /**
  * An Android target
  */
@@ -46,17 +47,13 @@ abstract class AndroidTarget extends JavaLibTarget {
 
     protected abstract ManifestMerger2.MergeType getMergeType()
 
-
     @Override
-    protected Set<File> sourceDirs() {
-        return baseVariant.sourceSets.collect { SourceProvider provider ->
-            provider.javaDirectories
-        }.flatten() as Set<File>
-    }
-
-    @Override
-    protected Set<String> compileConfigurations() {
-        return ["compile", "${buildType}Compile", "${flavor}Compile", "${name}Compile"]
+    Scope getMain() {
+        return new Scope(project,
+                ["compile", "${buildType}Compile", "${flavor}Compile", "${name}Compile"] as Set,
+                baseVariant.sourceSets.collect { SourceProvider provider ->
+                    provider.javaDirectories
+                }.flatten() as Set<File>)
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/ExoPackageScope.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/ExoPackageScope.groovy
@@ -1,0 +1,85 @@
+package com.github.okbuilds.core.model
+
+import com.github.okbuilds.core.dependency.ExternalDependency
+import com.github.okbuilds.core.util.FileUtil
+import groovy.util.slurpersupport.GPathResult
+import org.gradle.api.Project
+import org.gradle.api.file.FileTree
+
+class ExoPackageScope extends Scope {
+
+    private final Scope base
+    private final String manifest
+
+    ExoPackageScope(Project project, Scope base, Set<String> exoPackageDependencies, String manifest) {
+        super(project, [])
+        this.base = base
+        this.manifest = manifest
+        extractDependencies(base, exoPackageDependencies)
+    }
+
+    String getAppClass() {
+        String appClass = null
+        XmlSlurper slurper = new XmlSlurper()
+        slurper.DTDHandler = null
+        GPathResult manifestXml = slurper.parse(project.file(manifest))
+        try {
+            appClass = manifestXml.application.@"android:name"
+            appClass = appClass.replaceAll('\\.', "/")
+        } catch (Exception ignored) {
+        }
+        if (appClass != null && !appClass.empty) {
+            base.sources.each { String sourceDir ->
+                FileTree found = project.fileTree(dir: sourceDir, includes:
+                        ["${appClass}.java"])
+                if (found.size() == 1) {
+                    appClass = FileUtil.getRelativePath(project.projectDir, found[0])
+                }
+            }
+        }
+        return appClass
+    }
+
+    private void extractDependencies(Scope base, Set<String> exoPackageDependencies) {
+        exoPackageDependencies.each { String exoPackageDep ->
+            String first // can denote either group or project name
+            String last // can denote either module or configuration name
+            boolean fullyQualified = false
+
+            if (exoPackageDep.contains(":")) {
+                List<String> parts = exoPackageDep.split(":")
+                first = parts[0]
+                last = parts[1]
+                fullyQualified = true
+            } else {
+                first = last = exoPackageDep
+            }
+
+            ExternalDependency externalDep = base.external.find { ExternalDependency externalDependency ->
+                boolean match = true
+                if (fullyQualified) {
+                    match &= externalDependency.group == first
+                }
+                match &= externalDependency.module == last
+                return match
+            }
+
+            if (externalDep != null) {
+                external.add(externalDep)
+            } else {
+                Target variantDep = base.targetDeps.find { Target variant ->
+                    boolean match = true
+                    if (fullyQualified) {
+                        match &= variant.name == last
+                    }
+                    match &= variant.path == first
+                    return match
+                }
+
+                if (variantDep != null) {
+                    targetDeps.add(variantDep)
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
@@ -1,0 +1,73 @@
+package com.github.okbuilds.core.model
+
+import com.github.okbuilds.core.dependency.ExternalDependency
+import com.github.okbuilds.core.util.FileUtil
+import com.github.okbuilds.core.util.ProjectUtil
+import com.github.okbuilds.okbuck.OkBuckGradlePlugin
+import groovy.transform.EqualsAndHashCode
+import org.apache.commons.io.FilenameUtils
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.UnknownConfigurationException
+
+@EqualsAndHashCode
+class Scope {
+
+    final Set<String> sources
+    final Set<String> resources
+    final Set<Target> targetDeps = [] as Set
+
+    protected final Project project
+    protected final Set<ExternalDependency> external = [] as Set
+
+    Scope(Project project, Collection<String> configurations, Set<File> sourceDirs = [], Set<File> resDirs = []) {
+        this.project = project
+        sources = FileUtil.getAvailable(project, sourceDirs)
+        resources = FileUtil.getAvailable(project, resDirs)
+        extractConfigurations(configurations)
+    }
+
+    Set<String> getExternalDeps() {
+        external.collect { ExternalDependency dependency ->
+            OkBuckGradlePlugin.depCache.get(dependency)
+        }
+    }
+
+    private void extractConfigurations(Collection<String> configurations) {
+        configurations.each { String configName ->
+            try {
+                Configuration configuration = project.configurations.getByName(configName)
+                Set<File> resolvedFiles = [] as Set
+                configuration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact artifact ->
+                    String identifier = artifact.id.componentIdentifier.displayName
+                    File dep = artifact.file
+
+                    resolvedFiles.add(dep)
+
+                    if (identifier.contains(" ")) {
+                        Target target = ProjectUtil.getTargetForOutput(project.gradle.rootProject, dep)
+                        if (target != null) {
+                            targetDeps.add(target)
+                        }
+                    } else {
+                        ExternalDependency dependency = new ExternalDependency(identifier, dep)
+                        external.add(dependency)
+                        OkBuckGradlePlugin.depCache.put(dependency)
+                    }
+                }
+
+                configuration.resolve().findAll { File resolved ->
+                    !resolvedFiles.contains(resolved)
+                }.each { File localDep ->
+                    ExternalDependency dependency = new ExternalDependency(
+                            "${project.path.replaceFirst(':', '').replaceAll(':', '_')}:${FilenameUtils.getBaseName(localDep.name)}:1.0.0",
+                            localDep)
+                    external.add(dependency)
+                    OkBuckGradlePlugin.depCache.put(dependency)
+                }
+            } catch (UnknownConfigurationException ignored) {
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
@@ -1,5 +1,7 @@
 package com.github.okbuilds.core.util
 
+import org.gradle.api.Project
+
 final class FileUtil {
 
     private FileUtil() {
@@ -22,5 +24,13 @@ final class FileUtil {
         OutputStream outputStream = new FileOutputStream(destination)
         outputStream.write(inputStream.bytes)
         outputStream.close()
+    }
+
+    static Set<String> getAvailable(Project project, Collection<File> files) {
+        return files.findAll { File file ->
+            file.exists()
+        }.collect { File file ->
+            getRelativePath(project.projectDir, file)
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
@@ -24,8 +24,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
 
     static final String GROUP = "okbuck"
 
-    DependencyCache dependencyCache
-
+    static DependencyCache depCache
     static Logger LOGGER
 
     void apply(Project project) {
@@ -34,7 +33,7 @@ class OkBuckGradlePlugin implements Plugin<Project> {
         InstallExtension install = okbuck.extensions.create(INSTALL, InstallExtension, project)
         okbuck.extensions.create(EXPERIMENTAL, ExperimentalExtension)
 
-        dependencyCache = new DependencyCache(project, ".okbuck/cache")
+        depCache = new DependencyCache(project, ".okbuck/cache")
 
         Task okBuckClean = project.task(OKBUCK_CLEAN)
         okBuckClean.setGroup(GROUP)

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
@@ -24,7 +24,8 @@ final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
         }.findAll { String cpuFilter -> cpuFilter != null }
 
         return new AndroidBinaryRule(bin(target), ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
-                target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns, target.exopackage,
-                mappedCpuFilters, target.minifyEnabled, target.proguardConfig, target.placeholders)
+                target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns,
+                target.exopackage != null, mappedCpuFilters, target.minifyEnabled,
+                target.proguardConfig, target.placeholders)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -15,10 +15,10 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     static AndroidLibraryRule compose(AndroidLibTarget target, List<String> deps,
                                       List<String> aptDeps, List<String> aidlRuleNames,
                                       String appClass) {
-        deps.addAll(external(target.compileDeps))
-        deps.addAll(targets(target.targetCompileDeps))
+        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(targets(target.main.targetDeps))
 
-        target.targetCompileDeps.each { Target targetDep ->
+        target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {
                 targetDep.resources.each { AndroidTarget.ResBundle bundle ->
                     deps.add(res(targetDep, bundle))
@@ -31,7 +31,7 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        return new AndroidLibraryRule(src(target), ["PUBLIC"], deps, target.sources,
+        return new AndroidLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
                 target.manifest, target.annotationProcessors as List, aptDeps, aidlRuleNames,
                 appClass, target.sourceCompatibility, target.targetCompatibility,
                 postprocessClassesCommands, target.jvmArgs)

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidManifestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidManifestRuleComposer.groovy
@@ -14,11 +14,11 @@ final class AndroidManifestRuleComposer extends AndroidBuckRuleComposer {
     static AndroidManifestRule compose(AndroidAppTarget target) {
         List<String> deps = []
 
-        deps.addAll(external(target.compileDeps.findAll { String dep ->
+        deps.addAll(external(target.main.externalDeps.findAll { String dep ->
             dep.endsWith("aar")
         }))
 
-        deps.addAll(targets(target.targetCompileDeps.findAll { Target targetDep ->
+        deps.addAll(targets(target.main.targetDeps.findAll { Target targetDep ->
             targetDep instanceof AndroidLibTarget
         }))
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -13,11 +13,11 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
     static AndroidResourceRule compose(AndroidTarget target, AndroidTarget.ResBundle resBundle) {
         List<String> resDeps = new ArrayList<>()
 
-        resDeps.addAll(external(target.compileDeps.findAll { String dep ->
+        resDeps.addAll(external(target.main.externalDeps.findAll { String dep ->
             dep.endsWith(".aar")
         }))
 
-        target.targetCompileDeps.each { Target targetDep ->
+        target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {
                 targetDep.resources.each { AndroidTarget.ResBundle bundle ->
                     resDeps.add(res(targetDep, bundle))

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AptRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AptRuleComposer.groovy
@@ -10,6 +10,6 @@ final class AptRuleComposer extends JavaBuckRuleComposer {
     }
 
     static AptRule compose(Target target) {
-        return new AptRule(aptJar(target), external(target.aptDeps) as List)
+        return new AptRule(aptJar(target), external(target.apt.externalDeps) as List)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
@@ -1,10 +1,8 @@
 package com.github.okbuilds.okbuck.composer
 
 import com.github.okbuilds.core.model.AndroidAppTarget
-import com.github.okbuilds.core.model.Target
 import com.github.okbuilds.okbuck.generator.RetroLambdaGenerator
 import com.github.okbuilds.okbuck.rule.ExopackageAndroidLibraryRule
-import org.apache.commons.lang3.tuple.Pair
 
 final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
 
@@ -14,10 +12,9 @@ final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleComposer
 
     static ExopackageAndroidLibraryRule compose(AndroidAppTarget target) {
         List<String> deps = []
-        Pair<Set<String>, Set<Target>> appLibDependencies = target.appLibDependencies
 
-        deps.addAll(external(appLibDependencies.left))
-        deps.addAll(targets(appLibDependencies.right))
+        deps.addAll(external(target.exopackage.externalDeps))
+        deps.addAll(targets(target.exopackage.targetDeps))
         deps.add(":${buildConfig(target)}")
 
         List<String> postprocessClassesCommands = []
@@ -25,7 +22,7 @@ final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleComposer
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        return new ExopackageAndroidLibraryRule(appLib(target), target.appClass, ["PUBLIC"], deps,
+        return new ExopackageAndroidLibraryRule(appLib(target), target.exopackage.appClass, ["PUBLIC"], deps,
                 target.sourceCompatibility, target.targetCompatibility, postprocessClassesCommands,
                 target.jvmArgs)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/GenAidlRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/GenAidlRuleComposer.groovy
@@ -11,6 +11,6 @@ final class GenAidlRuleComposer extends AndroidBuckRuleComposer {
 
     static GenAidlRule compose(AndroidTarget target, String aidlDir) {
         return new GenAidlRule(aidl(target), aidlDir, "${target.path}/${aidlDir}",
-                targets(target.targetCompileDeps))
+                targets(target.main.targetDeps))
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -12,19 +12,19 @@ final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
 
     static JavaLibraryRule compose(JavaLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.compileDeps))
-        deps.addAll(targets(target.targetCompileDeps))
+        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(targets(target.main.targetDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(external(target.aptDeps))
-        aptDeps.addAll(targets(target.targetAptDeps))
+        aptDeps.addAll(external(target.apt.externalDeps))
+        aptDeps.addAll(targets(target.apt.targetDeps))
 
         List<String> postprocessClassesCommands = []
         if (target.retrolambda) {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaLibraryRule(src(target), ["PUBLIC"], deps, target.sources,
+        new JavaLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
                 target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
@@ -12,19 +12,19 @@ final class JavaTestRuleComposer extends JavaBuckRuleComposer {
 
     static JavaTestRule compose(JavaLibTarget target) {
         List<String> deps = [":${src(target)}"]
-        deps.addAll(external(target.testCompileDeps))
-        deps.addAll(targets(target.targetTestCompileDeps))
+        deps.addAll(external(target.test.externalDeps))
+        deps.addAll(targets(target.test.targetDeps))
 
         Set<String> aptDeps = [] as Set
-        aptDeps.addAll(external(target.aptDeps))
-        aptDeps.addAll(targets(target.targetAptDeps))
+        aptDeps.addAll(external(target.apt.externalDeps))
+        aptDeps.addAll(targets(target.apt.targetDeps))
 
         List<String> postprocessClassesCommands = []
         if (target.retrolambda) {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaTestRule(test(target), ["PUBLIC"], deps, target.testSources,
+        new JavaTestRule(test(target), ["PUBLIC"], deps, target.test.sources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
                 target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
@@ -81,12 +81,12 @@ final class BuckFileGenerator {
 
         // Apt
         List<String> aptDeps = []
-        if (!target.annotationProcessors.empty && !target.aptDeps.empty) {
+        if (!target.annotationProcessors.empty && !target.apt.externalDeps.empty) {
             AptRule aptRule = AptRuleComposer.compose(target)
             rules.add(aptRule)
             aptDeps.add(":${aptRule.name}")
         }
-        aptDeps.addAll(BuckRuleComposer.targets(target.targetAptDeps))
+        aptDeps.addAll(BuckRuleComposer.targets(target.apt.targetDeps))
 
         // Jni
         androidLibRules.addAll(target.jniLibs.collect { String jniLib ->
@@ -110,7 +110,7 @@ final class BuckFileGenerator {
         List<String> deps = [":${AndroidBuckRuleComposer.src(target)}"]
 
         Set<BuckRule> libRules = createRules((AndroidLibTarget) target,
-                target.exopackage ? target.appClass : null)
+                target.exopackage ? target.exopackage.appClass : null)
         rules.addAll(libRules)
 
         libRules.each { BuckRule rule ->


### PR DESCRIPTION
- Condense sources/resources/dependencies (external and targets) into `Scope`. Some example scopes are `main` , `test`, `apt` etc.
- Cleanup the target internals using scopes
- Gets rid of calling abstract methods in the target constructors