### PR TITLE
Support provided/compile only configurations

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
@@ -29,11 +29,20 @@ abstract class JavaTarget extends Target {
      */
     @Memoized
     Scope getApt() {
-        Scope aptScope = new Scope(project, ["apt", "provided", 'compileOnly'])
+        Scope aptScope = new Scope(project, ['apt', 'provided', 'compileOnly'])
         aptScope.targetDeps.retainAll(aptScope.targetDeps.findAll { Target target ->
             target.getProp(okbuck.annotationProcessors, null) != null
         })
         return aptScope
+    }
+
+    /**
+     * Provided Scope
+     */
+    @Memoized
+    Scope getProvided() {
+        Scope providedScope = new Scope(project, ['provided', 'compileOnly'])
+        return providedScope
     }
 
     /**

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -15,8 +15,8 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     static AndroidLibraryRule compose(AndroidLibTarget target, List<String> deps,
                                       List<String> aptDeps, List<String> aidlRuleNames,
                                       String appClass) {
-        deps.addAll(external(target.main.externalDeps))
-        deps.addAll(targets(target.main.targetDeps))
+        deps.addAll(external(target.main.externalDeps + target.provided.externalDeps))
+        deps.addAll(targets(target.main.targetDeps + target.provided.targetDeps))
 
         target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -12,8 +12,8 @@ final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
 
     static JavaLibraryRule compose(JavaLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.main.externalDeps))
-        deps.addAll(targets(target.main.targetDeps))
+        deps.addAll(external(target.main.externalDeps + target.provided.externalDeps))
+        deps.addAll(targets(target.main.targetDeps + target.provided.targetDeps))
 
         Set<String> aptDeps = [] as Set
         aptDeps.addAll(external(target.apt.externalDeps))


### PR DESCRIPTION
Resolves #62 

These dependencies are not exported and are only used to compile the target similar to gradle behavior