### PR TITLE
Proper fix for provided configurations

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
@@ -29,20 +29,11 @@ abstract class JavaTarget extends Target {
      */
     @Memoized
     Scope getApt() {
-        Scope aptScope = new Scope(project, ['apt', 'provided', 'compileOnly'])
+        Scope aptScope = new Scope(project, ["apt", "provided", 'compileOnly'])
         aptScope.targetDeps.retainAll(aptScope.targetDeps.findAll { Target target ->
             target.getProp(okbuck.annotationProcessors, null) != null
         })
         return aptScope
-    }
-
-    /**
-     * Provided Scope
-     */
-    @Memoized
-    Scope getProvided() {
-        Scope providedScope = new Scope(project, ['provided', 'compileOnly'])
-        return providedScope
     }
 
     /**

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
@@ -21,6 +21,8 @@ class Scope {
     protected final Project project
     protected final Set<ExternalDependency> external = [] as Set
 
+    private final Set<File> files = [] as Set
+
     Scope(Project project, Collection<String> configurations, Set<File> sourceDirs = [], Set<File> resDirs = []) {
         this.project = project
         sources = FileUtil.getAvailable(project, sourceDirs)
@@ -32,6 +34,10 @@ class Scope {
         external.collect { ExternalDependency dependency ->
             OkBuckGradlePlugin.depCache.get(dependency)
         }
+    }
+
+    String getClasspath(){
+        return files.collect{ it.absolutePath }.join(':')
     }
 
     private void extractConfigurations(Collection<String> configurations) {
@@ -66,6 +72,8 @@ class Scope {
                     external.add(dependency)
                     OkBuckGradlePlugin.depCache.put(dependency)
                 }
+
+                files.addAll(resolvedFiles)
             } catch (UnknownConfigurationException ignored) {
             }
         }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -15,8 +15,8 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
     static AndroidLibraryRule compose(AndroidLibTarget target, List<String> deps,
                                       List<String> aptDeps, List<String> aidlRuleNames,
                                       String appClass) {
-        deps.addAll(external(target.main.externalDeps + target.provided.externalDeps))
-        deps.addAll(targets(target.main.targetDeps + target.provided.targetDeps))
+        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(targets(target.main.targetDeps))
 
         target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -31,6 +31,10 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
+        if (!target.apt.classpath.empty) {
+            target.jvmArgs.addAll(['-classpath', target.apt.classpath])
+        }
+
         return new AndroidLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
                 target.manifest, target.annotationProcessors as List, aptDeps, aidlRuleNames,
                 appClass, target.sourceCompatibility, target.targetCompatibility,

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -12,8 +12,8 @@ final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
 
     static JavaLibraryRule compose(JavaLibTarget target) {
         List<String> deps = []
-        deps.addAll(external(target.main.externalDeps + target.provided.externalDeps))
-        deps.addAll(targets(target.main.targetDeps + target.provided.targetDeps))
+        deps.addAll(external(target.main.externalDeps))
+        deps.addAll(targets(target.main.targetDeps))
 
         Set<String> aptDeps = [] as Set
         aptDeps.addAll(external(target.apt.externalDeps))

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -24,6 +24,10 @@ final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
+        if (!target.apt.classpath.empty) {
+            target.jvmArgs.addAll(['-classpath', target.apt.classpath])
+        }
+
         new JavaLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
                 target.annotationProcessors, aptDeps, target.sourceCompatibility,
                 target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)


### PR DESCRIPTION
It seems the dependencies in the deps block are not exposed to other rules that depend on a rule, but they do end up in the final apk which is not desirable, even if the compilation part works :)

This change makes the dependencies part of the compilation classpath via the jvm args which is what the provided plugin does in gradle.

See: https://github.com/nebula-plugins/gradle-extra-configurations-plugin/blob/master/src/main/groovy/nebula/plugin/extraconfigurations/ProvidedBasePlugin.groovy

I am reverting the earlier change for provided scope. Ref #62 