### PR TITLE
Adding support for generating project_config rules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ android:
 
 script:
   - bash ./gradlew okbuck installBuck &&
-    ./buck build appDevDebug appDevRelease appProdDebug appProdRelease another-appDebug another-appRelease
+    ./buck build appDevDebug appDevRelease appProdDebug appProdRelease another-appDebug another-appRelease &&
+    ./buck project --ide intellij &&
+    ./buck project --ide intellij --deprecated-ij-generation
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ okbuck {
                     '^com/squareup/leakcanary/LeakCanary^',
             ]
     ]
+    projectTargets = [
+            'app': 'devDebug',
+            'common': 'freeRelease',
+            'dummylibrary': 'freeRelease',
+    ]
     exopackage = [
             appDebug: true
     ]
@@ -100,7 +105,8 @@ okbuck {
 +  `linearAllocHardLimit` and `primaryDexPatterns` are maps, configuration used by buck for multidex. For more details about multidex configuration, please read the
 [Multidex wiki page](https://github.com/OkBuilds/OkBuck/wiki/Multidex-Configuration-Guide), 
 if you don't need multidex, you can ignore these parameters
-+  `exopackage`, `appClassSource` and `appLibDependencies` are used for 
++  `projectTargets` is a map of project name to the buck target to use when generating an IntelliJ project.
++  `exopackage`, `appClassSource` and `appLibDependencies` are used for
 configuring buck's exopackage mode. For more details about exopackage configuration, 
 please read the [Exopackage wiki page](https://github.com/OkBuilds/OkBuck/wiki/Exopackage-Configuration-Guide), if you don't need exopackage, you can ignore these parameters
 + `annotationProcessors` is used to depend on annotation processors declared locally as another gradle module in the same root project.

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,12 @@ okbuck {
         gitUrl 'https://github.com/OkBuilds/buck.git'
         sha 'okbuck'
     }
+
+    projectTargets = [
+            'app': 'devDebug',
+            'common': 'freeRelease',
+            'dummylibrary': 'freeRelease',
+    ]
 }
 
 task clean(type: Delete) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/ProjectUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/ProjectUtil.groovy
@@ -45,7 +45,9 @@ final class ProjectUtil {
                 }
                 break
             case ProjectType.JAVA_LIB:
-                ["${JavaLibTarget.MAIN}": new JavaLibTarget(project, JavaLibTarget.MAIN)]
+                def targets = new HashMap<String, Target>()
+                targets.put(JavaLibTarget.MAIN, new JavaLibTarget(project, JavaLibTarget.MAIN))
+                return targets
                 break
             default:
                 [:]

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
@@ -30,6 +30,11 @@ class OkBuckExtension {
     Map<String, List<String>> primaryDexPatterns = [:]
 
     /**
+     * Configure the targets for project generation
+     */
+    Map<String, String> projectTargets = [:]
+
+    /**
      * Whether to enable exopackage.
      */
     Map<String, Boolean> exopackage = [:]

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ProjectConfigComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ProjectConfigComposer.groovy
@@ -1,0 +1,35 @@
+package com.github.okbuilds.okbuck.composer
+
+import com.github.okbuilds.core.model.AndroidAppTarget
+import com.github.okbuilds.core.model.AndroidLibTarget
+import com.github.okbuilds.core.model.AndroidTarget
+import com.github.okbuilds.core.model.JavaLibTarget
+import com.github.okbuilds.core.model.JavaTarget
+import com.github.okbuilds.core.model.Target
+import com.github.okbuilds.okbuck.rule.ProjectConfigRule
+
+import static com.github.okbuilds.okbuck.composer.AndroidBuckRuleComposer.bin
+
+class ProjectConfigComposer extends JavaBuckRuleComposer {
+
+    private ProjectConfigComposer() {
+        // no instance
+    }
+
+    static ProjectConfigRule composeAndroidApp(AndroidAppTarget androidAppTarget) {
+        return compose(bin(androidAppTarget), androidAppTarget)
+    }
+
+    static ProjectConfigRule composeLibrary(JavaTarget javaTarget) {
+        return compose(src(javaTarget), javaTarget)
+    }
+
+    private static ProjectConfigRule compose(String targetName, JavaTarget target) {
+        Set<String> mainSources = new LinkedHashSet<>()
+        Set<String> testSources = new LinkedHashSet<>()
+        mainSources.addAll(target.main.sources)
+        testSources.addAll(target.test.sources)
+
+        return new ProjectConfigRule(targetName, mainSources, null, testSources)
+    }
+}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/BuckRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/BuckRule.groovy
@@ -19,7 +19,10 @@ abstract class BuckRule {
      */
     void print(PrintStream printer) {
         printer.println("${mRuleType}(")
-        printer.println("\tname = '${name}',")
+
+        if (name != null) {
+            printer.println("\tname = '${name}',")
+        }
         printContent(printer)
         if (!mDeps.empty) {
             printer.println("\tdeps = [")

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/ProjectConfigRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/ProjectConfigRule.groovy
@@ -1,0 +1,39 @@
+package com.github.okbuilds.okbuck.rule
+
+final class ProjectConfigRule extends BuckRule {
+    private final String mSrcTarget;
+    private final Set<String> mSrcRoots;
+    private final String mTestTarget;
+    private final Set<String> mTestRoots;
+
+    ProjectConfigRule(String srcTarget, Set<String> srcRoots, String testTarget, Set<String> testRoots) {
+        super("project_config", null)
+        this.mSrcTarget = srcTarget
+        this.mSrcRoots = srcRoots
+        this.mTestTarget = testTarget
+        this.mTestRoots = testRoots
+    }
+
+    @Override
+    protected void printContent(PrintStream printer) {
+        printer.println("\tsrc_target = ':${mSrcTarget}',")
+
+        printer.println("\tsrc_roots = [")
+        for (String src : mSrcRoots) {
+            printer.println("\t\t'${src}',")
+        }
+        printer.println("\t],")
+
+        if (mTestTarget != null) {
+            printer.println("\ttest_target = '${mTestTarget}',")
+        }
+
+        if (mTestRoots != null && !mTestRoots.empty) {
+            printer.println("\ttest_roots = [")
+            for (String src : mTestRoots) {
+                printer.println("\t\t'${src}',")
+            }
+            printer.println("\t],")
+        }
+    }
+}


### PR DESCRIPTION
This adds support for generating [project_config](https://buckbuild.com/rule/project_config.html) rules so OkBuck consumers can use the [project](https://buckbuild.com/command/project.html) command to generate an IntelliJ project.

Unfortunately, there can only be one project_config rule per BUCK file. This means the the project_config `srcTarget` needs to reference the primary target for the BUCK file.

This default to use the `debug` variant for Android apps and the `release` variant for Android libraries. If a user wants to customize this, they can use the Gradle extension.

Test Plan: Added project generation (using both new generator and old generator) to Travis CI configuration.

(Unrelated, but `project_config` will be going away with the new project generator in Buck, but that still has some issues. This will still be useful for people on older versions of Buck and until the issues are ironed out.)

Fixes https://github.com/OkBuilds/OkBuck/issues/119