### PR TITLE
Add support for resources and resources_root to java_library and java_test rules.

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaLibTarget.groovy
@@ -26,12 +26,20 @@ class JavaLibTarget extends JavaTarget {
 
     @Override
     Scope getMain() {
-        return new Scope(project, ["compile"], project.files("src/main/java") as Set)
+        return new Scope(project,
+                ["compile"],
+                project.files("src/main/java") as Set,
+                project.file("src/main/resources"),
+                project.compileJava.options.compilerArgs + extraJvmArgs as List<String>)
     }
 
     @Override
     Scope getTest() {
-        return new Scope(project, ["testCompile"], project.files("src/test/java") as Set)
+        return new Scope(project,
+                ["testCompile"],
+                project.files("src/test/java") as Set,
+                project.file("src/test/resources"),
+                project.compileTestJava.options.compilerArgs + extraJvmArgs as List<String>)
     }
 
     String getSourceCompatibility() {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Scope.groovy
@@ -14,17 +14,25 @@ import org.gradle.api.artifacts.UnknownConfigurationException
 @EqualsAndHashCode
 class Scope {
 
+    final String resourcesDir
     final Set<String> sources
-    final Set<String> resources
     final Set<Target> targetDeps = [] as Set
+    List<String> jvmArgs
 
     protected final Project project
     protected final Set<ExternalDependency> external = [] as Set
 
-    Scope(Project project, Collection<String> configurations, Set<File> sourceDirs = [], Set<File> resDirs = []) {
+    Scope(Project project,
+          Collection<String> configurations,
+          Set<File> sourceDirs = [],
+          File resDir = null,
+          List<String> jvmArguments = []) {
+
         this.project = project
         sources = FileUtil.getAvailable(project, sourceDirs)
-        resources = FileUtil.getAvailable(project, resDirs)
+        resourcesDir = FileUtil.getAvailableFile(project, resDir)
+        jvmArgs = jvmArguments
+
         extractConfigurations(configurations)
     }
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/FileUtil.groovy
@@ -15,7 +15,7 @@ final class FileUtil {
             return path.substring(rootPath.length() + 1)
         } else {
             throw new IllegalArgumentException("sub dir ${dir.name} must " +
-                    "locate inside root dir ${rootDir.name}")
+                    "locate inside resourcesDir dir ${rootDir.name}")
         }
     }
 
@@ -27,10 +27,18 @@ final class FileUtil {
     }
 
     static Set<String> getAvailable(Project project, Collection<File> files) {
-        return files.findAll { File file ->
-            file.exists()
-        }.collect { File file ->
-            getRelativePath(project.projectDir, file)
+        if (!files) { return [] }
+
+        files.collect { File file ->
+            getAvailableFile(project, file)
+        }.findAll { String filePath ->
+            filePath
         }
+    }
+
+    static String getAvailableFile(Project project, File file) {
+        if (!file || !file.exists()) { return null }
+
+        return getRelativePath(project.projectDir, file)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidLibraryRuleComposer.groovy
@@ -26,7 +26,7 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
         target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {
                 targetDep.resources.each { AndroidTarget.ResBundle bundle ->
-                    deps.add(res(targetDep, bundle))
+                    deps.add(res(targetDep as AndroidTarget, bundle))
                 }
             }
         }
@@ -36,9 +36,20 @@ final class AndroidLibraryRuleComposer extends AndroidBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        return new AndroidLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
-                target.manifest, target.annotationProcessors as List, aptDeps, providedDeps,
-                aidlRuleNames, appClass, target.sourceCompatibility, target.targetCompatibility,
-                postprocessClassesCommands, target.jvmArgs)
+        return new AndroidLibraryRule(
+                src(target),
+                ["PUBLIC"],
+                deps,
+                target.main.sources,
+                target.manifest,
+                target.annotationProcessors as List,
+                aptDeps,
+                providedDeps,
+                aidlRuleNames,
+                appClass,
+                target.sourceCompatibility,
+                target.targetCompatibility,
+                postprocessClassesCommands,
+                target.main.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -20,7 +20,7 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
         target.main.targetDeps.each { Target targetDep ->
             if (targetDep instanceof AndroidTarget) {
                 targetDep.resources.each { AndroidTarget.ResBundle bundle ->
-                    resDeps.add(res(targetDep, bundle))
+                    resDeps.add(res(targetDep as AndroidTarget, bundle))
                 }
             }
         }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/ExopackageAndroidLibraryRuleComposer.groovy
@@ -24,6 +24,6 @@ final class ExopackageAndroidLibraryRuleComposer extends AndroidBuckRuleComposer
 
         return new ExopackageAndroidLibraryRule(appLib(target), target.exopackage.appClass, ["PUBLIC"], deps,
                 target.sourceCompatibility, target.targetCompatibility, postprocessClassesCommands,
-                target.jvmArgs)
+                target.exopackage.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaLibraryRuleComposer.groovy
@@ -29,8 +29,19 @@ final class JavaLibraryRuleComposer extends JavaBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaLibraryRule(src(target), ["PUBLIC"], deps, target.main.sources,
-                target.annotationProcessors, aptDeps, providedDeps, target.sourceCompatibility,
-                target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
+        new JavaLibraryRule(
+                src(target),
+                ["PUBLIC"],
+                deps,
+                target.main.sources,
+                target.annotationProcessors,
+                aptDeps,
+                providedDeps,
+                target.main.resourcesDir,
+                target.sourceCompatibility,
+                target.targetCompatibility,
+                postprocessClassesCommands,
+                target.main.jvmArgs)
     }
+
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/JavaTestRuleComposer.groovy
@@ -2,6 +2,7 @@ package com.github.okbuilds.okbuck.composer
 
 import com.github.okbuilds.core.model.JavaLibTarget
 import com.github.okbuilds.okbuck.generator.RetroLambdaGenerator
+import com.github.okbuilds.okbuck.rule.JavaLibraryRule
 import com.github.okbuilds.okbuck.rule.JavaTestRule
 
 final class JavaTestRuleComposer extends JavaBuckRuleComposer {
@@ -11,7 +12,8 @@ final class JavaTestRuleComposer extends JavaBuckRuleComposer {
     }
 
     static JavaTestRule compose(JavaLibTarget target) {
-        List<String> deps = [":${src(target)}"]
+        List<String> deps = []
+        deps.add(":${src(target)}")
         deps.addAll(external(target.test.externalDeps))
         deps.addAll(targets(target.test.targetDeps))
 
@@ -29,8 +31,18 @@ final class JavaTestRuleComposer extends JavaBuckRuleComposer {
             postprocessClassesCommands.add(RetroLambdaGenerator.generate(target))
         }
 
-        new JavaTestRule(test(target), ["PUBLIC"], deps, target.test.sources,
-                target.annotationProcessors, aptDeps, providedDeps, target.sourceCompatibility,
-                target.targetCompatibility, postprocessClassesCommands, target.jvmArgs)
+        new JavaTestRule(
+                test(target),
+                ["PUBLIC"],
+                deps,
+                target.test.sources,
+                target.annotationProcessors,
+                aptDeps,
+                providedDeps,
+                target.test.resourcesDir,
+                target.sourceCompatibility,
+                target.targetCompatibility,
+                postprocessClassesCommands,
+                target.test.jvmArgs)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidLibraryRule.groovy
@@ -19,11 +19,20 @@ final class AndroidLibraryRule extends BuckRule {
      * @param appClass , if exopackage is enabled, pass the detected app class, otherwise, pass null
      * */
     AndroidLibraryRule(
-            String name, List<String> visibility, List<String> deps, Set<String> srcSet,
-            String manifest, List<String> annotationProcessors, List<String> aptDeps,
-            Set<String> providedDeps, List<String> aidlRuleNames, String appClass,
-            String sourceCompatibility, String targetCompatibility,
-            List<String> postprocessClassesCommands, List<String> options) {
+            String name,
+            List<String> visibility,
+            List<String> deps,
+            Set<String> srcSet,
+            String manifest,
+            List<String> annotationProcessors,
+            List<String> aptDeps,
+            Set<String> providedDeps,
+            List<String> aidlRuleNames,
+            String appClass,
+            String sourceCompatibility,
+            String targetCompatibility,
+            List<String> postprocessClassesCommands,
+            List<String> options) {
         super("android_library", name, visibility, deps)
 
         mSrcSet = srcSet

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaLibraryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaLibraryRule.groovy
@@ -2,13 +2,33 @@ package com.github.okbuilds.okbuck.rule
 
 final class JavaLibraryRule extends JavaRule {
 
-    JavaLibraryRule(String name, List<String> visibility, List<String> deps,
-                    Set<String> srcSet, Set<String> annotationProcessors,
-                    Set<String> aptDeps, Set<String> providedDeps, String sourceCompatibility,
-                    String targetCompatibility, List<String> postprocessClassesCommands,
-                    List<String> options) {
-        super("java_library", name, visibility, deps, srcSet, annotationProcessors,
-                aptDeps, providedDeps, sourceCompatibility, targetCompatibility,
-                postprocessClassesCommands, options)
+    JavaLibraryRule(
+            String name,
+            List<String> visibility,
+            List<String> deps,
+            Set<String> srcSet,
+            Set<String> annotationProcessors,
+            Set<String> aptDeps,
+            Set<String> providedDeps,
+            String resourcesDir,
+            String sourceCompatibility,
+            String targetCompatibility,
+            List<String> postprocessClassesCommands,
+            List<String> options) {
+
+        super(
+                "java_library",
+                name,
+                visibility,
+                deps,
+                srcSet,
+                annotationProcessors,
+                aptDeps,
+                providedDeps,
+                resourcesDir,
+                sourceCompatibility,
+                targetCompatibility,
+                postprocessClassesCommands,
+                options)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaRule.groovy
@@ -4,23 +4,35 @@ abstract class JavaRule extends BuckRule {
     private final Set<String> mSrcSet
     private final Set<String> mAnnotationProcessors
     private final Set<String> mAnnotationProcessorDeps
+    private final String mResourcesDir
     private final String mSourceCompatibility
     private final String mTargetCompatibility
     private final List<String> mPostprocessClassesCommands
     private final List<String> mOptions
     private final Set<String> mProvidedDeps
 
-    JavaRule(String ruleType, String name, List<String> visibility, List<String> deps,
-             Set<String> srcSet, Set<String> annotationProcessors,
-             Set<String> aptDeps, Set<String> providedDeps, String sourceCompatibility,
-             String targetCompatibility, List<String> postprocessClassesCommands,
-             List<String> options) {
+    JavaRule(
+            String ruleType,
+            String name,
+            List<String> visibility,
+            List<String> deps,
+            Set<String> srcSet,
+            Set<String> annotationProcessors,
+            Set<String> aptDeps,
+            Set<String> providedDeps,
+            String resourcesDir,
+            String sourceCompatibility,
+            String targetCompatibility,
+            List<String> postprocessClassesCommands,
+            List<String> options) {
+
         super(ruleType, name, visibility, deps)
         mSrcSet = srcSet
         mAnnotationProcessors = annotationProcessors
         mAnnotationProcessorDeps = aptDeps
         mSourceCompatibility = sourceCompatibility
         mTargetCompatibility = targetCompatibility
+        mResourcesDir = resourcesDir
         mPostprocessClassesCommands = postprocessClassesCommands
         mOptions = options
         mProvidedDeps = providedDeps
@@ -34,6 +46,14 @@ abstract class JavaRule extends BuckRule {
                 printer.println("\t\t'${src}/**/*.java',")
             }
             printer.println("\t]),")
+        }
+
+        if (mResourcesDir) {
+            printer.println("\tresources = glob([")
+            printer.println("\t\t'${mResourcesDir}/**',")
+            printer.println("\t]),")
+
+            printer.println("\tresources_root = '${mResourcesDir}',")
         }
 
         if (!mAnnotationProcessors.empty) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaTestRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/JavaTestRule.groovy
@@ -2,13 +2,32 @@ package com.github.okbuilds.okbuck.rule
 
 final class JavaTestRule extends JavaRule {
 
-    JavaTestRule(String name, List<String> visibility, List<String> deps,
-                 Set<String> srcSet, Set<String> annotationProcessors,
-                 Set<String> aptDeps, Set<String> providedDeps, String sourceCompatibility,
-                 String targetCompatibility, List<String> postprocessClassesCommands,
-                 List<String> options) {
-        super("java_test", name, visibility, deps, srcSet, annotationProcessors,
-                aptDeps, providedDeps, sourceCompatibility, targetCompatibility,
-                postprocessClassesCommands, options)
+    JavaTestRule(
+            String name,
+            List<String> visibility,
+            List<String> deps,
+            Set<String> srcSet,
+            Set<String> annotationProcessors,
+            Set<String> aptDeps,
+            Set<String> providedDeps,
+            String resourcesDir,
+            String sourceCompatibility,
+            String targetCompatibility,
+            List<String> postprocessClassesCommands,
+            List<String> options) {
+        super(
+                "java_test",
+                name,
+                visibility,
+                deps,
+                srcSet,
+                annotationProcessors,
+                aptDeps,
+                providedDeps,
+                resourcesDir,
+                sourceCompatibility,
+                targetCompatibility,
+                postprocessClassesCommands,
+                options)
     }
 }


### PR DESCRIPTION
- eg:
```
java_test(
	name = 'test_main',
	srcs = glob([
		'src/test/java/**/*.java',
	]),
	resources = glob([
		'src/test/resources/**',
	]),
	resources_root = 'src/test/resources',
...
```
- move jvm args to scope