### PR TITLE
Promote manifest placeholders support from experimental to fully supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ okbuck {
     buckProjects = project.subprojects
     keep = []
 
-    experimental {
-        placeholderSupport true
-    }
-
     install {
         gitUrl 'https://github.com/OkBuilds/buck.git'
         sha 'okbuck'
@@ -112,8 +108,6 @@ please read the [Exopackage wiki page](https://github.com/OkBuilds/OkBuck/wiki/E
 + `annotationProcessors` is used to depend on annotation processors declared locally as another gradle module in the same root project.
 +  `buckProjects` is a set of projects to generate buck configs for. Default is all sub projects of the root project.
 + `keep` is a list of files to not clean up by the plugin when running `okbuckclean`. This may be useful to keep the `buck-out` folder around for faster incremental builds even when buck files are regenerated. Also useful if you want made manual modifications to some buck configuration and would like to keep it intact while regenerating the configuration for other projects.
-+ `experimental` is used to enable experimental features not available in buck upstream, but available in our [fork](https://github.com/OkBuilds/buck/tree/okbuck)
- - `placeholderSupport` - Enables supprot for [manifest placeholders](http://tools.android.com/tech-docs/new-build-system/user-guide/manifest-merger#TOC-Placeholder-support)
 + `install` is used to download and install buck from the [official version](https://github.com/facebook/buck) or from any fork. It keeps a cache of different forks you can use across your projects. To install the specified version you need to explictly run the `buckInstall` task and can use it via the `buck` symlink in your project.
  - `gitUrl` - The git url of the buck fork. Default is [facebook/buck](https://github.com/facebook/buck)
  - `sha` - The git sha/branch/tag to checkout before building. Defaults to origin/master

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3'
     }
 }
 
@@ -69,13 +68,8 @@ okbuck {
     ]
     buckProjects = project.subprojects.findAll { it.name != "plugin" }
 
-    experimental {
-        placeholderSupport true
-    }
-
     install {
-        gitUrl 'https://github.com/OkBuilds/buck.git'
-        sha 'okbuck'
+        sha '2d937846d94b3372a5f784dc6d5c730f0c09cdc8'
     }
 
     projectTargets = [

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     compile 'commons-lang:commons-lang:2.6'
     compile 'org.apache.maven:maven-artifact:3.3.9'
     compile 'com.android.tools.build:gradle:2.1.0'
+
+    testCompile 'junit:junit:4.12'
 }
 
 def siteUrl = 'https://github.com/OkBuilds/OkBuck'

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/annotation/Experimental.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/annotation/Experimental.groovy
@@ -6,5 +6,5 @@ import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
 @Retention(RetentionPolicy.SOURCE)
-@Target([ElementType.METHOD, ElementType.FIELD])
+@Target([ElementType.TYPE, ElementType.METHOD, ElementType.FIELD])
 @interface Experimental {}

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -3,9 +3,7 @@ package com.github.okbuilds.core.model
 import com.android.build.gradle.api.BaseVariant
 import com.android.builder.model.SigningConfig
 import com.android.manifmerger.ManifestMerger2
-import com.github.okbuilds.core.annotation.Experimental
 import com.github.okbuilds.core.util.FileUtil
-import com.github.okbuilds.okbuck.ExperimentalExtension
 import groovy.transform.ToString
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
@@ -14,7 +12,6 @@ import org.gradle.api.Project
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
-
 /**
  * An Android app target
  */
@@ -35,7 +32,6 @@ class AndroidAppTarget extends AndroidLibTarget {
 
     final boolean minifyEnabled
 
-    @Experimental
     final Map<String, Object> placeholders = [:]
 
     AndroidAppTarget(Project project, String name) {
@@ -61,12 +57,9 @@ class AndroidAppTarget extends AndroidLibTarget {
             exopackage = null
         }
 
-        ExperimentalExtension experimental = okbuck.experimental
-        if (experimental.placeholderSupport) {
-            placeholders.put('applicationId', applicationId + applicationIdSuffix)
-            placeholders.putAll(baseVariant.buildType.manifestPlaceholders)
-            placeholders.putAll(baseVariant.mergedFlavor.manifestPlaceholders)
-        }
+        placeholders.put('applicationId', applicationId + applicationIdSuffix)
+        placeholders.putAll(baseVariant.buildType.manifestPlaceholders)
+        placeholders.putAll(baseVariant.mergedFlavor.manifestPlaceholders)
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/GitUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/GitUtil.groovy
@@ -27,12 +27,12 @@ class GitUtil {
     }
 
     /**
-     * Checks out a given sha/branch/tag on a repo
+     * Checks out a given ref (sha/branch/tag) on a repo
      * @param repoDir The git repository directory
-     * @param repoDir The git sha/branch/tag
+     * @param repoDir The git ref/branch/tag
      */
-    static void checkout(File repoDir, String sha, String remoteName) {
-        CmdUtil.run("git -C ${repoDir.absolutePath} checkout ${remoteName}/${sha}")
+    static void checkout(File repoDir, String ref) {
+        CmdUtil.run("git -C ${repoDir.absolutePath} checkout ${ref}")
     }
 
     /**

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/InstallUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/InstallUtil.groovy
@@ -10,7 +10,7 @@ class InstallUtil {
 
     private InstallUtil() {}
 
-    static void install(Project project, BuildSystem build, String gitUrl, String sha, File cacheDir) {
+    static void install(Project project, BuildSystem build, String gitUrl, String ref, File cacheDir) {
         cacheDir.mkdirs()
         File repoDir = new File(cacheDir, build.name)
 
@@ -20,15 +20,13 @@ class InstallUtil {
         }
 
         def remoteUrl = build.gitUrl
-        def remoteName = "origin"
         if (gitUrl != null && !gitUrl.empty) {
             remoteUrl = gitUrl
-            remoteName = GitUtil.remoteName(remoteUrl)
         }
 
         GitUtil.addRemote(repoDir, remoteUrl)
         GitUtil.fetchAll(repoDir)
-        GitUtil.checkout(repoDir, sha, remoteName)
+        GitUtil.checkout(repoDir, ref)
 
         build.installer.install(project, repoDir)
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/ExperimentalExtension.groovy
@@ -1,10 +1,6 @@
 package com.github.okbuilds.okbuck
 
-import org.apache.http.annotation.Experimental
+import com.github.okbuilds.core.annotation.Experimental
 
 @Experimental
-class ExperimentalExtension {
-
-    // Enables support for manifest placeholders
-    boolean placeholderSupport = false
-}
+class ExperimentalExtension { }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/InstallExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/InstallExtension.groovy
@@ -1,9 +1,7 @@
 package com.github.okbuilds.okbuck
 
-import org.apache.http.annotation.Experimental
 import org.gradle.api.Project
 
-@Experimental
 class InstallExtension {
 
     String dir

--- a/dummylibrary/build.gradle
+++ b/dummylibrary/build.gradle
@@ -43,13 +43,14 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-
     provided 'com.google.dagger:dagger-compiler:2.0.1'
+
     compile project(':libraries:javalibrary')
-    freeCompile project(path: ':libraries:common', configuration: 'freeDebug')
-    paidCompile project(path: ':libraries:common', configuration: 'paidRelease')
     compile('com.pushtorefresh.storio:sqlite:1.3.0') {
         exclude module: 'support-annotations'
     }
+    freeCompile project(path: ':libraries:common', configuration: 'freeDebug')
+    paidCompile project(path: ':libraries:common', configuration: 'paidRelease')
+
+    testCompile 'junit:junit:4.12'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/libraries/javalibrary/build.gradle
+++ b/libraries/javalibrary/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'nebula.provided-base'
 apply plugin: 'me.tatarka.retrolambda'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -8,8 +7,8 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.google.dagger:dagger:2.0.1'
-    provided 'org.glassfish:javax.annotation:10.0-b28'
-    provided 'com.google.dagger:dagger-compiler:2.0.1'
+    compileOnly 'org.glassfish:javax.annotation:10.0-b28'
+    compileOnly 'com.google.dagger:dagger-compiler:2.0.1'
 
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
- Use `compileOnly` instead of `provided` for java projects
- Update Gradle to 2.14
- Use latest buck master
- Cleanup install task