### PR TITLE
Support to add extra buck options to rules

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -18,6 +18,7 @@ import java.util.zip.ZipFile
 class AndroidAppTarget extends AndroidLibTarget {
 
     private static final int DEFAULT_LINEARALLOC_LIMIT = 7194304
+    private static final String BINARY_OPT = "binary"
 
     final boolean multidexEnabled
     final boolean debuggable
@@ -33,6 +34,7 @@ class AndroidAppTarget extends AndroidLibTarget {
     final boolean minifyEnabled
 
     final Map<String, Object> placeholders = [:]
+    final Set<String> extraOpts
 
     AndroidAppTarget(Project project, String name) {
         super(project, name)
@@ -60,6 +62,8 @@ class AndroidAppTarget extends AndroidLibTarget {
         placeholders.put('applicationId', applicationId + applicationIdSuffix)
         placeholders.putAll(baseVariant.buildType.manifestPlaceholders)
         placeholders.putAll(baseVariant.mergedFlavor.manifestPlaceholders)
+
+        extraOpts = getProp(okbuck.extraBuckOpts, [:]).get(BINARY_OPT, [])
     }
 
     @Override

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckExtension.groovy
@@ -54,6 +54,11 @@ class OkBuckExtension {
      */
     List<String> keep = []
 
+    /**
+     * Extra buck options
+     */
+    Map<String, Map<String, List<String>>> extraBuckOpts = [:]
+
     OkBuckExtension(Project project) {
         buckProjects = project.subprojects
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBinaryRuleComposer.groovy
@@ -26,6 +26,6 @@ final class AndroidBinaryRuleComposer extends AndroidBuckRuleComposer {
         return new AndroidBinaryRule(bin(target), ["PUBLIC"], deps, manifestRuleName, keystoreRuleName,
                 target.multidexEnabled, target.linearAllocHardLimit, target.primaryDexPatterns,
                 target.exopackage != null, mappedCpuFilters, target.minifyEnabled,
-                target.proguardConfig, target.placeholders)
+                target.proguardConfig, target.placeholders, target.extraOpts)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidBinaryRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/AndroidBinaryRule.groovy
@@ -11,11 +11,12 @@ final class AndroidBinaryRule extends BuckRule {
     private final boolean mMinifyEnabled
     private final String mProguardConfig
     private final Map<String, Object> mPlaceholders
+    private final Set<String> mExtraOpts
 
     AndroidBinaryRule(String name, List<String> visibility, List<String> deps, String manifest, String keystore,
                       boolean multidexEnabled, int linearAllocHardLimit, Set<String> primaryDexPatterns,
                       boolean exopackage, Set<String> cpuFilters, boolean minifyEnabled,
-                      String proguardConfig, Map<String, Object> placeholders) {
+                      String proguardConfig, Map<String, Object> placeholders, Set<String> extraOpts) {
         super("android_binary", name, visibility, deps)
 
         mManifest = manifest
@@ -28,6 +29,7 @@ final class AndroidBinaryRule extends BuckRule {
         mMinifyEnabled = minifyEnabled
         mProguardConfig = proguardConfig
         mPlaceholders = placeholders
+        mExtraOpts = extraOpts
     }
 
     @Override
@@ -69,6 +71,10 @@ final class AndroidBinaryRule extends BuckRule {
             }
             printer.println("\t\t},")
             printer.println("\t},")
+        }
+
+        mExtraOpts.each { String option ->
+            printer.println("\t${option},")
         }
     }
 }


### PR DESCRIPTION
Add an option to enable extra options on `android_binary` rules. These rules by far have the most number of undocumented options which makes it hard to support them all officially without adding bloat. We can later extend this to provide support for other rules as needed.

Going to leave this undocumented in readme as this api is still in flux.