### PR TITLE
Extract target dependencies and populate cache before creating rule to make sure all projects are on the same version of dependencies.

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
@@ -24,7 +24,7 @@ class DependencyCache {
         }
 
         ExternalDependency externalDependency = greatestVersions.get(dependency)
-        if (externalDependency == null || dependency.version.compareTo(externalDependency.version) > 0) {
+        if (externalDependency == null || dependency.version > externalDependency.version) {
             greatestVersions.put(dependency, dependency)
         }
     }
@@ -44,10 +44,9 @@ class DependencyCache {
             if (!thirdPartyBuckFile.exists()) {
                 copyThirdPartyBuckFile(cachedCopy.parentFile)
             }
-            return path
-        } else {
-            return finalDepFiles.get(dependency)
         }
+
+        return finalDepFiles.get(greatestVersion)
     }
 
     private static void copyThirdPartyBuckFile(File dstDir) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/ExternalDependency.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/ExternalDependency.groovy
@@ -16,4 +16,9 @@ class ExternalDependency extends VersionlessDependency {
         version = new DefaultArtifactVersion(parts[2])
         this.depFile = depFile
     }
+
+    @Override
+    String toString() {
+        return "${this.version} : ${this.depFile.toString()}"
+    }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -92,10 +92,10 @@ abstract class AndroidTarget extends JavaLibTarget {
     List<String> getBuildConfigFields() {
         return ["String BUILD_TYPE = \"${buildType}\"",
                 "String FLAVOR = \"${flavor}\"",
-        ].plus(baseVariant.mergedFlavor.buildConfigFields.collect {
+        ] + baseVariant.mergedFlavor.buildConfigFields.collect {
             String key, ClassField classField ->
                 "${classField.type} ${key} = ${classField.value}"
-        })
+        }
     }
 
     String getFlavor() {
@@ -122,7 +122,7 @@ abstract class AndroidTarget extends JavaLibTarget {
             [project.file(asset).parentFile.path, asset]
         }
 
-        return resourceMap.keySet().plus(assetMap.keySet()).collect { key ->
+        return (resourceMap.keySet() + assetMap.keySet()).collect { key ->
             new ResBundle(identifier, resourceMap.get(key, null), assetMap.get(key, null))
         } as Set
     }
@@ -139,7 +139,6 @@ abstract class AndroidTarget extends JavaLibTarget {
         }.flatten() as Set<String>
     }
 
-    @Memoized
     String getManifest() {
         Set<String> manifests = [] as Set
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
@@ -67,4 +67,13 @@ abstract class JavaTarget extends Target {
                 return '7'
         }
     }
+
+    @Override
+    public void resolve() {
+        super.resolve()
+
+        getApt()
+        getMain()
+        getTest()
+    }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/JavaTarget.groovy
@@ -27,7 +27,6 @@ abstract class JavaTarget extends Target {
     /**
      * Apt Scope
      */
-    @Memoized
     Scope getApt() {
         Scope aptScope = new Scope(project, ["apt", "provided", 'compileOnly'])
         aptScope.targetDeps.retainAll(aptScope.targetDeps.findAll { Target target ->
@@ -39,16 +38,15 @@ abstract class JavaTarget extends Target {
     /**
      * List of annotation processor classes.
      */
-    @Memoized
     Set<String> getAnnotationProcessors() {
-        return apt.externalDeps.collect { String aptDep ->
+        return (apt.externalDeps.collect { String aptDep ->
             JarFile jar = new JarFile(new File(aptDep))
             jar.entries().findAll { JarEntry entry ->
-                entry.name.equals("META-INF/services/javax.annotation.processing.Processor")
+                (entry.name == "META-INF/services/javax.annotation.processing.Processor")
             }.collect { JarEntry aptEntry ->
                 IOUtils.toString(jar.getInputStream(aptEntry)).trim().split("\\n")
             }
-        }.plus(apt.targetDeps.collect { Target target ->
+        } + apt.targetDeps.collect { Target target ->
             (List<String>) target.getProp(okbuck.annotationProcessors, null)
         }.findAll { List<String> processors ->
             processors != null

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/Target.groovy
@@ -56,4 +56,8 @@ abstract class Target {
     def getProp(Map map, defaultValue) {
         return map.get("${identifier}${name}", map.get(identifier, defaultValue))
     }
+
+    public void resolve() {
+        // no scope to resolve
+    }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/ProjectUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/ProjectUtil.groovy
@@ -6,7 +6,6 @@ import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.BaseVariantOutput
 import com.github.okbuilds.core.model.*
 import com.github.okbuilds.okbuck.OkBuckExtension
-import groovy.transform.Memoized
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
@@ -17,7 +16,6 @@ final class ProjectUtil {
         // no instance
     }
 
-    @Memoized
     static ProjectType getType(Project project) {
         if (project.plugins.hasPlugin(AppPlugin)) {
             return ProjectType.ANDROID_APP
@@ -30,7 +28,6 @@ final class ProjectUtil {
         }
     }
 
-    @Memoized
     static Map<String, Target> getTargets(Project project) {
         ProjectType type = getType(project)
         switch (type) {
@@ -55,7 +52,6 @@ final class ProjectUtil {
         }
     }
 
-    @Memoized
     static Target getTargetForOutput(Project rootProject, File output) {
         Target result = null
         OkBuckExtension okbuck = rootProject.okbuck
@@ -70,7 +66,7 @@ final class ProjectUtil {
                     def baseVariants = project.android.libraryVariants
                     baseVariants.all { BaseVariant baseVariant ->
                         def variant = baseVariant.outputs.find { BaseVariantOutput out ->
-                            out.outputFile.equals(output)
+                            (out.outputFile == output)
                         }
                         if (variant != null) {
                             result = new AndroidLibTarget(project, variant.name)

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
@@ -26,7 +26,7 @@ final class BuckFileGenerator {
      */
     Map<Project, BUCKFile> generate() {
         mOkbuck.buckProjects.each { Project project ->
-            extractDependencyAndPopulateCache(project)
+            resolve(project)
         }
 
         Map<Project, List<BuckRule>> projectRules = mOkbuck.buckProjects.collectEntries { Project project ->
@@ -45,24 +45,11 @@ final class BuckFileGenerator {
         } as Map<Project, BUCKFile>
     }
 
-    private static void extractDependencyAndPopulateCache(Project project) {
-
-        ProjectType projectType = ProjectUtil.getType(project)
+    private static void resolve(Project project) {
         Map<String, Target> targets = ProjectUtil.getTargets(project)
 
         targets.each { String name, Target target ->
-            switch (projectType) {
-                case ProjectType.JAVA_LIB:
-                case ProjectType.ANDROID_LIB:
-                case ProjectType.ANDROID_APP:
-                    JavaLibTarget currentTarget = (JavaLibTarget) target
-                    currentTarget.getApt()
-                    currentTarget.getMain()
-                    currentTarget.getTest()
-                    break
-                default:
-                    break
-            }
+            target.resolve()
         }
     }
 


### PR DESCRIPTION
 - Buck file generator goes through each project one by one and to gets all its rules.
 - If a rule is created for a project which is very low in (near leaf) in the hierarchy then the resolved dependencies (in the rule) might differ from its parent ones (or from the project in a completely disjoint tree)
 - This diff is resolving configuration and extracting dependencies before creating rules.