### PR TITLE
Cleanup cache structure and remove digest from rulenames when not needed

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/dependency/DependencyCache.groovy
@@ -1,7 +1,6 @@
 package com.github.okbuilds.core.dependency
 
 import com.github.okbuilds.core.util.FileUtil
-import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Project
 
@@ -15,13 +14,13 @@ class DependencyCache {
     private Map<VersionlessDependency, String> finalDepFiles = [:]
     private Map<VersionlessDependency, ExternalDependency> greatestVersions = [:]
 
-    static digestFormat = { File depFile ->
-        "${DigestUtils.md5Hex(depFile.parentFile.absolutePath)}/${depFile.name}"
+    static flatFormat = { File depFile ->
+        depFile.name
     }
 
     DependencyCache(Project rootProject,
                     String cacheDirPath,
-                    Closure<String> fileFormat = digestFormat,
+                    Closure<String> fileFormat = flatFormat,
                     createBuckFile = true) {
         this.rootProject = rootProject
         cacheDir = new File(rootProject.projectDir, cacheDirPath)

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -128,8 +128,9 @@ abstract class AndroidTarget extends JavaLibTarget {
             [project.file(asset).parentFile.path, asset]
         }
 
-        return (resourceMap.keySet() + assetMap.keySet()).collect { key ->
-            new ResBundle(identifier, resourceMap.get(key, null), assetMap.get(key, null))
+        Set<String> keys = (resourceMap.keySet() + assetMap.keySet())
+        return keys.collect { key ->
+            new ResBundle(identifier, resourceMap.get(key, null), assetMap.get(key, null), keys.size() > 1)
         } as Set
     }
 
@@ -193,10 +194,14 @@ abstract class AndroidTarget extends JavaLibTarget {
         String resDir
         String assetsDir
 
-        ResBundle(String identifier, String resDir, String assetsDir) {
+        ResBundle(String identifier, String resDir, String assetsDir, boolean digestId = true) {
             this.resDir = resDir
             this.assetsDir = assetsDir
-            id = DigestUtils.md5Hex("${identifier}:${resDir}:${assetsDir}")
+            if (digestId) {
+                id = DigestUtils.md5Hex("${identifier}:${resDir}:${assetsDir}")
+            } else {
+                id = null
+            }
         }
     }
 

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/util/RobolectricUtil.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/util/RobolectricUtil.groovy
@@ -53,7 +53,7 @@ class RobolectricUtil {
         Set<File> sourceDirs = []
         List<String> jvmArguments = []
         runtimeDeps.each { Configuration configuration ->
-            DependencyCache cache = new DependencyCache(project, ROBOLECTRIC_CACHE, { File depFile -> depFile.name }, false)
+            DependencyCache cache = new DependencyCache(project, ROBOLECTRIC_CACHE, DependencyCache.flatFormat, false)
             Scope runtimeDepsScope = new Scope(project, [configuration.name], sourceDirs, res, jvmArguments, cache)
             runtimeDepsScope.getExternalDeps()
         }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/OkBuckGradlePlugin.groovy
@@ -62,15 +62,17 @@ class OkBuckGradlePlugin implements Plugin<Project> {
             InstallUtil.install(project, BuildSystem.BUCK, install.gitUrl, install.sha, new File(install.dir))
         }
 
-        Task fetchRobolectricRuntimeDeps = project.task('fetchRobolectricRuntimeDeps')
-        okBuck.dependsOn(fetchRobolectricRuntimeDeps)
-        fetchRobolectricRuntimeDeps.mustRunAfter(okBuckClean)
-        fetchRobolectricRuntimeDeps.setDescription("Fetches runtime dependencies for robolectric")
-
-        fetchRobolectricRuntimeDeps << {
+        project.afterEvaluate {
             ExperimentalExtension experimental = okbuck.experimental
             if (experimental.robolectric) {
-                RobolectricUtil.download(project)
+                Task fetchRobolectricRuntimeDeps = project.task('fetchRobolectricRuntimeDeps')
+                okBuck.dependsOn(fetchRobolectricRuntimeDeps)
+                fetchRobolectricRuntimeDeps.mustRunAfter(okBuckClean)
+                fetchRobolectricRuntimeDeps.setDescription("Fetches runtime dependencies for robolectric")
+
+                fetchRobolectricRuntimeDeps << {
+                    RobolectricUtil.download(project)
+                }
             }
         }
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
@@ -10,7 +10,7 @@ abstract class AndroidBuckRuleComposer extends JavaBuckRuleComposer {
     }
 
     static String resLocal(AndroidTarget target, AndroidTarget.ResBundle bundle) {
-        return "res_${target.name}_${bundle.id}"
+        return "res_${target.name}${bundle.id ? "_${bundle.id}" : ""}"
     }
 
     static String manifest(AndroidTarget target) {


### PR DESCRIPTION
Fixes #144

- Remove digest calculation from dependency cache to make okbuck task faster. Hashing is already handled by buck
- Simplify `android_resource` rule names when only one resource and asset folders are available per target
- Do not add robolectric tasks when not enabled