### PR TITLE
Use project filetree instead of file name filter

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/task/OkBuildCleanTask.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/task/OkBuildCleanTask.groovy
@@ -18,8 +18,8 @@ class OkBuildCleanTask extends DefaultTask {
 
     @TaskAction
     void clean() {
-        new FileNameFinder().getFileNames(project.projectDir.absolutePath, remove.join(' '), keep.join(' ')).each {
-            FileUtils.deleteQuietly(project.file(it))
+        project.fileTree(dir: project.projectDir.absolutePath, includes: remove, excludes: keep).each { File f ->
+            FileUtils.deleteQuietly(f)
         }
     }
 }


### PR DESCRIPTION
- This resolves a transient build failure in certain projects due to xerces