### PR TITLE
Move BuildConfig application ID to base AndroidTarget

### DIFF
--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidAppTarget.groovy
@@ -69,13 +69,6 @@ class AndroidAppTarget extends AndroidLibTarget {
     }
 
     @Override
-    List<String> getBuildConfigFields() {
-        List<String> buildConfig = super.getBuildConfigFields()
-        buildConfig.add("String APPLICATION_ID = \"${applicationId + applicationIdSuffix}\"")
-        return buildConfig
-    }
-
-    @Override
     protected BaseVariant getBaseVariant() {
         return (BaseVariant) project.android.applicationVariants.find { it.name == name }
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -132,6 +132,7 @@ abstract class AndroidTarget extends JavaLibTarget {
 
     List<String> getBuildConfigFields() {
         List<String> buildConfig = [
+            "String APPLICATION_ID = \"${applicationId + applicationIdSuffix}\"",
             "String BUILD_TYPE = \"${buildType}\"",
             "String FLAVOR = \"${flavor}\"",
         ]
@@ -145,7 +146,6 @@ abstract class AndroidTarget extends JavaLibTarget {
             String key, ClassField classField ->
                 "${classField.type} ${key} = ${classField.value}"
         }
-        buildConfig.add("String APPLICATION_ID = \"${applicationId + applicationIdSuffix}\"")
 
         return buildConfig
     }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/core/model/AndroidTarget.groovy
@@ -145,6 +145,7 @@ abstract class AndroidTarget extends JavaLibTarget {
             String key, ClassField classField ->
                 "${classField.type} ${key} = ${classField.value}"
         }
+        buildConfig.add("String APPLICATION_ID = \"${applicationId + applicationIdSuffix}\"")
 
         return buildConfig
     }


### PR DESCRIPTION
This moves the ApplicationId part of the build config generator to the base AndroidTarget in a similar fashion to: https://github.com/OkBuilds/OkBuck/commit/3e3d818fe6ced9d15ea6962f54b73841fe12c1ca

This will generate the following for a library:

```python
android_build_config(
    ...
	package = 'com.package.lib',
	values = [
         ...
		'String APPLICATION_ID = "com.package.lib"',
         ...
	],
    ...
)
```

And remain the same for an application:

```python
android_build_config(
    ...
	package = 'com.package.app',
	values = [
         ...
		'String APPLICATION_ID = "com.package.app"',
         ...
	],
    ...
)
```