### PR TITLE
Generate android_resource rule names based on directory name

### DIFF
--- a/buckw
+++ b/buckw
@@ -4,7 +4,7 @@
 ##
 ##  Buck wrapper script to invoke okbuck when needed, before running buck
 ##
-##  Created by OkBuck Gradle Plugin on : Fri Sep 16 12:55:04 CDT 2016
+##  Created by OkBuck Gradle Plugin on : Fri Sep 16 14:00:25 CDT 2016
 ##
 #########################################################################
 
@@ -182,7 +182,7 @@ setupBuckRun ( ) {
         if [ ! -z $CUSTOM_BUCK_REPO ]; then
             REMOTE_NAME=$(printf '%s' $CUSTOM_BUCK_REPO | md5digest | cut -d ' ' -f 1)
             cd $BUCK_HOME
-            REMOTE_EXISTS=$(git remote -v | grep '$REMOTE_NAME')
+            REMOTE_EXISTS=$(git remote -v | grep "$REMOTE_NAME")
             if [ -z "$REMOTE_EXISTS" ]; then
                 git remote add $REMOTE_NAME $CUSTOM_BUCK_REPO
             fi

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidBuckRuleComposer.groovy
@@ -6,11 +6,11 @@ import com.github.okbuilds.core.model.AndroidTarget
 abstract class AndroidBuckRuleComposer extends JavaBuckRuleComposer {
 
     static String res(AndroidTarget target, AndroidTarget.ResBundle bundle) {
-        return "//${target.path}:${resLocal(target, bundle)}"
+        return "//${target.path}:${resLocal(bundle)}"
     }
 
-    static String resLocal(AndroidTarget target, AndroidTarget.ResBundle bundle) {
-        return "res_${target.name}${bundle.id ? "_${bundle.id}" : ""}"
+    static String resLocal(AndroidTarget.ResBundle bundle) {
+        return "res_${bundle.name}"
     }
 
     static String manifest(AndroidTarget target) {

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/composer/AndroidResourceRuleComposer.groovy
@@ -25,7 +25,7 @@ final class AndroidResourceRuleComposer extends AndroidBuckRuleComposer {
             }
         }
 
-        return new AndroidResourceRule(resLocal(target, resBundle), ["PUBLIC"], resDeps,
+        return new AndroidResourceRule(resLocal(resBundle), ["PUBLIC"], resDeps,
                 target.applicationId, resBundle.resDir, resBundle.assetsDir)
     }
 }

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/generator/BuckFileGenerator.groovy
@@ -63,7 +63,7 @@ final class BuckFileGenerator {
                     rules.addAll(createRules((AndroidLibTarget) target))
                     break
                 case ProjectType.ANDROID_APP:
-                    List<BuckRule> targetRules = createRules((AndroidAppTarget) target);
+                    List<BuckRule> targetRules = createRules((AndroidAppTarget) target)
                     rules.addAll(targetRules)
                     if (espresso && ((AndroidAppTarget) target).instrumentationTestVariant) {
                         AndroidInstrumentationTarget instrumentationTarget =
@@ -75,6 +75,11 @@ final class BuckFileGenerator {
                 default:
                     break
             }
+        }
+
+        // de-dup rules by name
+        rules = rules.unique { rule ->
+            rule.name
         }
 
         return rules

--- a/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/BuckRule.groovy
+++ b/buildSrc/src/main/groovy/com/github/okbuilds/okbuck/rule/BuckRule.groovy
@@ -4,14 +4,14 @@ abstract class BuckRule {
 
     final String name
     private final String mRuleType
-    private final List<String> mVisibility
-    private final List<String> mDeps
+    private final Set<String> mVisibility
+    private final Set<String> mDeps
 
     BuckRule(String ruleType, String name, List<String> visibility = [], List<String> deps = []) {
         this.name = name
         mRuleType = ruleType
-        mVisibility = visibility
-        mDeps = deps
+        mVisibility = new LinkedHashSet(visibility)
+        mDeps = new LinkedHashSet(deps) // de-dup dependencies
     }
 
     /**

--- a/buildSrc/src/main/resources/com/github/okbuilds/core/util/wrapper/BUCKW_TEMPLATE
+++ b/buildSrc/src/main/resources/com/github/okbuilds/core/util/wrapper/BUCKW_TEMPLATE
@@ -181,7 +181,7 @@ setupBuckRun ( ) {
         if [ ! -z $CUSTOM_BUCK_REPO ]; then
             REMOTE_NAME=$(printf '%s' $CUSTOM_BUCK_REPO | md5digest | cut -d ' ' -f 1)
             cd $BUCK_HOME
-            REMOTE_EXISTS=$(git remote -v | grep '$REMOTE_NAME')
+            REMOTE_EXISTS=$(git remote -v | grep "$REMOTE_NAME")
             if [ -z "$REMOTE_EXISTS" ]; then
                 git remote add $REMOTE_NAME $CUSTOM_BUCK_REPO
             fi


### PR DESCRIPTION
This uses the res/asset folder parent directory name to name the `android_resource` rule target names. This makes the generated buck files a lot more readable and closer to how gradle source sets work.