### PR TITLE
Fix buck wrapper by calling okbuck tasks instead of :okbuck

### DIFF
--- a/buckw
+++ b/buckw
@@ -132,7 +132,7 @@ runOkBuck ( ) {
     fi
 
     rm -f $OKBUCK_SUCCESS
-    ( $WORKING_DIR/gradlew -p $WORKING_DIR :okbuck -Dokbuck.wrapper=true $EXTRA_ARGS --stacktrace && updateOkBuckSuccess && success "PROCEEDING WITH BUCK" ) || die "OKBUCK FAILED"
+    ( $WORKING_DIR/gradlew -p $WORKING_DIR okbuck -Dokbuck.wrapper=true $EXTRA_ARGS --stacktrace && updateOkBuckSuccess && success "PROCEEDING WITH BUCK" ) || die "OKBUCK FAILED"
 }
 
 watchmanWorkflow ( ) {


### PR DESCRIPTION
I noticed that buckw wasn't showing expected behavior and tracked down the fix to removing the colon when calling `okbuck`. As far as I can tell this is correct anyway as colons are used to specify subprojects in gradle but `okbuck` is a task, not a subproject.